### PR TITLE
Perfom validation matrix multiply on CPU

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -225,13 +225,11 @@ def evaluate(model, data, epoch, args, tb_writer=None, steps=None):
 
 def get_metrics(image_features, text_features):
     metrics = {}
-    logits_per_image = image_features @ text_features.t()
-    logits_per_text = logits_per_image.t()
+    logits_per_image = (logit_scale * image_features @ text_features.t()).detach().cpu()
+    logits_per_text = logits_per_image.t().detach().cpu()
 
     logits = {"image_to_text": logits_per_image, "text_to_image": logits_per_text}
-    ground_truth = (
-        torch.arange(len(text_features)).view(-1, 1).to(logits_per_image.device)
-    )
+    ground_truth = torch.arange(len(text_features)).view(-1, 1)
 
     for name, logit in logits.items():
         ranking = torch.argsort(logit, descending=True)


### PR DESCRIPTION
The current codebase computes the validation accuracy on the GPU. If you have a validation set of ~20k examples, then this means you're multiplying a 20,000 x 20,000 matrix ~= 2GB of extra GPU memory. If you're maxing out the GPU memory for training the model, the extra 2GB can make a difference. This patch just moves it to the CPU. Things are a little bit slower, but it's not much in the grand scheme of things.