### PR TITLE
New flag to save most recent epoch

### DIFF
--- a/src/training/main.py
+++ b/src/training/main.py
@@ -213,6 +213,16 @@ def main_worker(gpu, ngpus_per_node, log_queue, args):
                     },
                     os.path.join(args.checkpoint_path, f"epoch_{epoch + 1}.pt"),
                 )
+            if args.save_most_recent:
+                torch.save(
+                    {
+                        "epoch": epoch + 1,
+                        "name": args.name,
+                        "state_dict": model.state_dict(),
+                        "optimizer": optimizer.state_dict(),
+                    },
+                    os.path.join(args.checkpoint_path, f"epoch_latest.pt"),
+                )
 
     if args.wandb and (args.gpu == 0 or (not args.distributed)):
         wandb.finish()

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -111,6 +111,12 @@ def parse_args():
         "--save-frequency", type=int, default=1, help="How often to save checkpoints."
     )
     parser.add_argument(
+        "--save-most-recent",
+        action="store_true",
+        default=False,
+        help="Always save the most recent model trained to epoch_latest.pt.",
+    )
+    parser.add_argument(
         "--zeroshot-frequency", type=int, default=2, help="How often to run zero shot."
     )
     parser.add_argument(


### PR DESCRIPTION
The current code supports flags to save every N epochs (including every 1 epoch) but this fills up disk space quickly for big models. This new flag always writes the most recent epoch to `epoch_latest.pt` with whatever the last checkpoint is, allowing someone to see the current progress without creating a hundred checkpoint files.