### PR TITLE
Remove DataParallel support. Minor cleanup.

### DIFF
--- a/src/training/distributed.py
+++ b/src/training/distributed.py
@@ -63,7 +63,6 @@ def init_distributed_device(args):
     # Distributed training = training on more than one GPU.
     # Also easily possible to extend to multiple nodes & multiple GPUs.
     args.distributed = False
-    args.dp = False
     args.world_size = 1
     args.rank = 0  # global rank
     args.local_rank = 0
@@ -97,11 +96,7 @@ def init_distributed_device(args):
             args.world_size = torch.distributed.get_world_size()
             args.rank = torch.distributed.get_rank()
         args.distributed = True
-    else:
-        # DP is still a world-size of 1
-        args.multigpu = []
-        if args.dp and not args.multigpu:
-            args.multigpu = list(range(torch.cuda.device_count()))
+
     if torch.cuda.is_available():
         if args.distributed and not args.no_set_device_rank:
             device = 'cuda:%d' % args.local_rank

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -53,7 +53,6 @@ def main():
 
     # discover initial world args early so we can log properly
     args.distributed = False
-    args.dp = False
     args.local_rank, args.rank, args.world_size = world_info_from_env()
 
     args.log_path = None
@@ -100,10 +99,7 @@ def main():
             f'Running in distributed mode with multiple processes. Device: {args.device}.'
             f'Process (global: {args.rank}, local {args.local_rank}), total {args.world_size}.')
     else:
-        if args.dp:
-            logging.info(f'Running with a single process, DataParallel on {len(args.multigpu)} GPUs.')
-        else:
-            logging.info(f'Running with a single process. Device {args.device}.')
+        logging.info(f'Running with a single process. Device {args.device}.')
 
     # Do not use skip_reset unless you want to use on of the CLIP model
     if args.openai_pretrained:
@@ -144,9 +140,6 @@ def main():
         if args.use_bn_sync:
             model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
         model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device])
-
-    if args.dp:
-        model = torch.nn.DataParallel(model, device_ids=args.multigpu)
 
     data = get_data(args, (preprocess_train, preprocess_val))
     assert len(data), 'At least one train or eval dataset must be specified'

--- a/src/training/model_configs/ViT-B-16.json
+++ b/src/training/model_configs/ViT-B-16.json
@@ -2,9 +2,9 @@
     "embed_dim": 512,
     "vision_cfg": {
         "image_size": 224,
-        "vision_layers": 12,
-        "vision_width": 768,
-        "vision_patch_size": 16
+        "layers": 12,
+        "width": 768,
+        "patch_size": 16
     },
     "text_cfg": {
         "context_length": 77,

--- a/src/training/model_configs/ViT-L-14.json
+++ b/src/training/model_configs/ViT-L-14.json
@@ -2,9 +2,9 @@
     "embed_dim": 768,
     "vision_cfg": {
         "image_size": 224,
-        "vision_layers": 24,
-        "vision_width": 1024,
-        "vision_patch_size": 14
+        "layers": 24,
+        "width": 1024,
+        "patch_size": 14
     },
     "text_cfg": {
         "context_length": 77,

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -95,7 +95,8 @@ def parse_args():
     parser.add_argument(
         "--warmup", type=int, default=10000, help="Number of steps to warmup for."
     )
-    parser.add_argument("--use-bn-sync",
+    parser.add_argument(
+        "--use-bn-sync",
         default=False,
         action="store_true",
         help="Whether to use batch norm sync.")
@@ -192,18 +193,6 @@ def parse_args():
         default=False,
         action="store_true",
         help="If true, we copy the entire base on the log diretory, and execute from there."
-    )
-    parser.add_argument(
-        "--dp",
-        default=False,
-        action="store_true",
-        help="Use DP instead of DDP."
-    )
-    parser.add_argument(
-        "--multigpu",
-        default=None,
-        type=lambda x: [int(a) for a in x.split(",")],
-        help="In DP, which GPUs to use for multigpu training",
     )
     parser.add_argument(
         "--horovod",

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -14,8 +14,6 @@ def zero_shot_classifier(model, classnames, templates, args):
             texts = clip.tokenize(texts).to(args.device) #tokenize
             if args.distributed and not args.horovod:
                 class_embeddings = model.module.encode_text(texts)
-            elif args.dp:
-                class_embeddings = model(None, texts)
             else:
                 class_embeddings = model.encode_text(texts)
             class_embeddings /= class_embeddings.norm(dim=-1, keepdim=True)
@@ -42,8 +40,6 @@ def run(model, classifier, dataloader, args):
             # predict
             if args.distributed and not args.horovod:
                 image_features = model.module.encode_image(images)
-            elif args.dp:
-                image_features = model(images, None)
             else:
                 image_features = model.encode_image(images)
             image_features /= image_features.norm(dim=-1, keepdim=True)


### PR DESCRIPTION
Given that DataParallel is slower than DistributedDataParallel in single-node, multi-device use, and has issues working with torchscript and has other modelling complications, is likely to be deprecated in PyTorch at some point, I feel it's best to remove support and always use DDP or Horovod w/ appropriate launcher (torchrun, horovodrun, slurm, etc) for multi-gpu.

 