### PR TITLE
Add missing training packages and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ cd open_clip
 python setup.py install
 ```
 
+If you want to train models, you will also need to install the packages
+from `requirements-training.txt`.
+
 ### Sample single-process running code:
 
 ```bash

--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -5,3 +5,4 @@ regex
 ftfy
 tqdm
 pandas
+braceexpand


### PR DESCRIPTION
There's a package necessary to build the latest code that's not included in the dependency file. This fixes that (and also adds a note to the README for how to fix set up the environment for running everything).