### PR TITLE
Add synthetic + real data benchmarking

### DIFF
--- a/src/training/benchmark.py
+++ b/src/training/benchmark.py
@@ -1,0 +1,303 @@
+from contextlib import suppress
+from lib2to3.pgen2.tokenize import tokenize
+import logging
+import math
+import os
+import random
+from datetime import datetime
+import time
+
+import numpy as np
+import torch
+from torch import optim
+from torch.cuda.amp import GradScaler
+
+from open_clip.loss import ClipLoss
+from open_clip import tokenize
+
+try:
+    import wandb
+except ImportError:
+    wandb = None
+
+try:
+    import torch.utils.tensorboard as tensorboard
+except ImportError:
+    tensorboard = None
+
+try:
+    import horovod.torch as hvd
+except ImportError:
+    hvd = None
+
+from open_clip import create_model_and_transforms, trace_model
+from training.data import get_data
+from training.distributed import is_master, init_distributed_device, world_info_from_env
+from training.logger import setup_logging
+from training.params import parse_args
+from training.scheduler import cosine_lr
+from training.train import train_one_epoch, evaluate, unwrap_model
+
+
+def random_seed(seed=42, rank=0):
+    torch.manual_seed(seed + rank)
+    np.random.seed(seed + rank)
+    random.seed(seed + rank)
+
+
+def main():
+    args = parse_args()
+
+    # sanitize model name for filesystem / uri use, easier if we don't use / in name as a rule?
+    args.model = args.model.replace('/', '-')
+
+    # get the name of the experiments
+    if args.name is None:
+        args.name = '-'.join([
+            datetime.now().strftime("%Y_%m_%d-%H_%M_%S"),
+            f"model_{args.model}",
+            f"lr_{args.lr}",
+            f"b_{args.batch_size}",
+            f"j_{args.workers}",
+            f"p_{args.precision}",
+        ])
+
+    # discover initial world args early so we can log properly
+    args.distributed = False
+    args.local_rank, args.rank, args.world_size = world_info_from_env()
+
+    args.log_path = None
+    if is_master(args, local=args.log_local):
+        log_base_path = os.path.join(args.logs, args.name)
+        os.makedirs(log_base_path, exist_ok=True)
+        log_filename = f'out-{args.rank}' if args.log_local else 'out.log'
+        args.log_path = os.path.join(log_base_path, log_filename)
+        if os.path.exists(args.log_path):
+            print(
+                "Error. Experiment already exists. Use --name {} to specify a new experiment."
+            )
+            return -1
+
+    # Set logger
+    args.log_level = logging.DEBUG if args.debug else logging.INFO
+    setup_logging(args.log_path, args.log_level)
+
+    # fully initialize distributed device environment
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cudnn.deterministic = False
+    device = init_distributed_device(args)
+
+    args.wandb = 'wandb' in args.report_to or 'all' in args.report_to
+    args.tensorboard = 'tensorboard' in args.report_to or 'all' in args.report_to
+    if is_master(args):
+        args.tensorboard_path = os.path.join(args.logs, args.name, "tensorboard") if args.tensorboard else ''
+        args.checkpoint_path = os.path.join(args.logs, args.name, "checkpoints")
+        for dirname in [args.tensorboard_path, args.checkpoint_path]:
+            if dirname:
+                os.makedirs(dirname, exist_ok=True)
+    else:
+        args.tensorboard_path = ''
+        args.checkpoint_path = ''
+
+    assert args.precision in ['amp', 'fp16', 'fp32']
+    if args.precision == 'fp16':
+        logging.warning(
+            'It is recommended to use AMP mixed-precision instead of FP16. '
+            'FP16 support needs further verification and tuning, especially for train.')
+
+    if args.horovod:
+        logging.info(
+            f'Running in horovod mode with multiple processes / nodes. Device: {args.device}.'
+            f'Process (global: {args.rank}, local {args.local_rank}), total {args.world_size}.')
+    elif args.distributed:
+        logging.info(
+            f'Running in distributed mode with multiple processes. Device: {args.device}.'
+            f'Process (global: {args.rank}, local {args.local_rank}), total {args.world_size}.')
+    else:
+        logging.info(f'Running with a single process. Device {args.device}.')
+
+    model, preprocess_train, preprocess_val = create_model_and_transforms(
+        args.model,
+        args.pretrained,
+        precision=args.precision,
+        device=device,
+        jit=args.torchscript,
+        force_quick_gelu=args.force_quick_gelu,
+        pretrained_image=args.pretrained_image,
+    )
+
+    if args.trace:
+        model = trace_model(model, batch_size=args.batch_size, device=device)
+
+    if args.lock_image:
+        # lock image tower as per LiT - https://arxiv.org/abs/2111.07991
+        model.lock_image_tower(
+            unlocked_groups=args.lock_image_unlocked_groups,
+            freeze_bn_stats=args.lock_image_freeze_bn_stats)
+
+    if args.grad_checkpointing:
+        model.set_grad_checkpointing()
+
+    if is_master(args):
+        logging.info("Model:")
+        logging.info(f"{str(model)}")
+        logging.info("Params:")
+        params_file = os.path.join(args.logs, args.name, "params.txt")
+        with open(params_file, "w") as f:
+            for name in sorted(vars(args)):
+                val = getattr(args, name)
+                logging.info(f"  {name}: {val}")
+                f.write(f"{name}: {val}\n")
+
+    if args.distributed and not args.horovod:
+        if args.use_bn_sync:
+            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+        ddp_args = {}
+        if args.ddp_static_graph:
+            # this doesn't exist in older PyTorch, arg only added if enabled
+            ddp_args['static_graph'] = True
+        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
+
+    # create optimizer and scaler
+    optimizer = None
+    scaler = None
+    assert not args.trace, 'Cannot train with traced model'
+
+    exclude = lambda n, p: p.ndim < 2 or "bn" in n or "ln" in n or "bias" in n or 'logit_scale' in n
+    include = lambda n, p: not exclude(n, p)
+
+    named_parameters = list(model.named_parameters())
+    gain_or_bias_params = [p for n, p in named_parameters if exclude(n, p) and p.requires_grad]
+    rest_params = [p for n, p in named_parameters if include(n, p) and p.requires_grad]
+
+    optimizer = optim.AdamW(
+        [
+            {"params": gain_or_bias_params, "weight_decay": 0.},
+            {"params": rest_params, "weight_decay": args.wd},
+        ],
+        lr=args.lr,
+        betas=(args.beta1, args.beta2),
+        eps=args.eps,
+    )
+    if args.horovod:
+        optimizer = hvd.DistributedOptimizer(optimizer, named_parameters=model.named_parameters())
+        hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+        hvd.broadcast_optimizer_state(optimizer, root_rank=0)
+
+    scaler = GradScaler() if args.precision == "amp" else None
+
+    # optionally resume from a checkpoint
+    start_epoch = 0
+    if args.resume is not None:
+        if os.path.isfile(args.resume):
+            checkpoint = torch.load(args.resume, map_location=device)
+            if 'epoch' in checkpoint:
+                # resuming a train checkpoint w/ epoch and optimizer state
+                start_epoch = checkpoint["epoch"]
+                sd = checkpoint["state_dict"]
+                if not args.distributed and next(iter(sd.items()))[0].startswith('module'):
+                    sd = {k[len('module.'):]: v for k, v in sd.items()}
+                model.load_state_dict(sd)
+                if optimizer is not None:
+                    optimizer.load_state_dict(checkpoint["optimizer"])
+                if scaler is not None and 'scaler' in checkpoint:
+                    scaler.load_state_dict(checkpoint['scaler'])
+                logging.info(f"=> resuming checkpoint '{args.resume}' (epoch {start_epoch})")
+            else:
+                # loading a bare (model only) checkpoint for fine-tune or evaluation
+                model.load_state_dict(checkpoint)
+                logging.info(f"=> loaded checkpoint '{args.resume}' (epoch {start_epoch})")
+        else:
+            logging.info("=> no checkpoint found at '{}'".format(args.resume))
+
+    # initialize datasets
+    if args.synthetic_data:
+        data = []
+    else:
+        data = get_data(args, (preprocess_train, preprocess_val), epoch=start_epoch)
+        assert len(data), 'At least one train or eval dataset must be specified.'
+
+    # create scheduler if train
+    scheduler = lambda x: x
+    if 'train' in data and optimizer is not None:
+        total_steps = data["train"].dataloader.num_batches * args.epochs
+        scheduler = cosine_lr(optimizer, args.lr, args.warmup, total_steps)
+
+    # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
+    args.save_logs = False
+
+    if is_master(args):
+        logging.info(f'Starting Benchmark')
+
+    device = torch.device(args.device)
+    autocast = torch.cuda.amp.autocast if args.precision == 'amp' else suppress
+
+    model.train()
+    loss = ClipLoss(
+        local_loss=args.local_loss,
+        gather_with_grad=args.gather_with_grad,
+        cache_labels=True,
+        rank=args.rank,
+        world_size=args.world_size,
+        use_horovod=args.horovod)
+
+    if args.synthetic_data:
+        dataloader = [0 for i in range(args.bench_steps)]
+    else:
+        dataloader, sampler = data['train'].dataloader, data['train'].sampler
+    if args.distributed and sampler is not None:
+        sampler.set_epoch(0)
+
+    t0 = time.perf_counter()
+    for i, batch in enumerate(dataloader):
+        if i == args.bench_steps:
+            break
+        step = i
+        scheduler(step)
+
+        if args.synthetic_data:
+            images = torch.randn(args.batch_size, 3, model.visual.image_size,
+                model.visual.image_size, device=device)
+            texts = tokenize("Test sentence")[0]
+            texts = torch.stack([texts] * args.batch_size)
+            texts = texts.to(device=device, non_blocking=True)
+        else:
+            images, texts = batch
+            images = images.to(device=device, non_blocking=True)
+            texts = texts.to(device=device, non_blocking=True)
+
+        optimizer.zero_grad()
+
+        with autocast():
+            image_features, text_features, logit_scale = model(images, texts)
+            total_loss = loss(image_features, text_features, logit_scale)
+
+        if scaler is not None:
+            scaler.scale(total_loss).backward()
+            if args.horovod:
+                optimizer.synchronize()
+                scaler.unscale_(optimizer)
+                with optimizer.skip_synchronize():
+                    scaler.step(optimizer)
+            else:
+                scaler.step(optimizer)
+            scaler.update()
+        else:
+            total_loss.backward()
+            optimizer.step()
+
+        # Note: we clamp to 4.6052 = ln(100), as in the original paper.
+        with torch.no_grad():
+            unwrap_model(model).logit_scale.clamp_(0, math.log(100))
+
+        # end for
+    t = time.perf_counter()
+    if is_master(args):
+        logging.info(f"Benchmarking completed in {t-t0} seconds.")
+        logging.info("Average Sample Throughput: " + 
+            f"{args.batch_size * args.world_size * args.bench_steps / (t-t0)} Samples/Second")
+
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/benchmark.py
+++ b/src/training/benchmark.py
@@ -296,7 +296,7 @@ def main():
 
             optimization_step += 1
             # end for
-        if optimization_step == args.bench_steps:
+        if optimization_step == args.bench_steps + args.bench_warmup:
             break
     t = time.perf_counter()
     if is_master(args):

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -306,6 +306,12 @@ def parse_args():
         default=1000,
         help="The number of steps to simulate during benchmarking."
     )
+    parser.add_argument(
+        "--bench-warmup",
+        type=int,
+        default=10,
+        help="The number of steps to skip before recording time"
+    )
     args = parser.parse_args()
 
     # If some params are not passed, we use the default values based on model name.

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -293,6 +293,19 @@ def parse_args():
     parser.add_argument(
         "--grad-clip-norm", type=float, default=None, help="Gradient clip."
     )
+    # benchmarking flags
+    parser.add_argument(
+        "--synthetic-data",
+        default=False,
+        action="store_true",
+        help="Use synthetic data to perform benchmarking."
+    )
+    parser.add_argument(
+        "--bench-steps",
+        type=int,
+        default=1000,
+        help="The number of steps to simulate during benchmarking."
+    )
     args = parser.parse_args()
 
     # If some params are not passed, we use the default values based on model name.


### PR DESCRIPTION
Adding benchmarking functionality through `benchmark.py`. It may be called identically to `main.py`. It includes 2 new flags:
- `--synthetic-data`, a boolean flag that allows a user to forgo data loading
- `--bench-steps`, an integer representing the number of steps to simulate

The only limitation is that this does NOT support crossing of the epoch boundary, thus real data scope is strictly less than the entire dataset size.