### PR TITLE
PosEmbed resizing, Image pre-processing flexibility, WDS resampled shard option, worker epoch synch improvements

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -1,7 +1,13 @@
 import torch
-import torch.distributed.nn
-from torch import distributed as dist, nn as nn
+import torch.nn as nn
 from torch.nn import functional as F
+
+try:
+    import torch.distributed.nn
+    from torch import distributed as dist
+    has_distributed = True
+except ImportError:
+    has_distributed = False
 
 try:
     import horovod.torch as hvd
@@ -18,6 +24,7 @@ def gather_features(
         world_size=1,
         use_horovod=False
 ):
+    assert has_distributed, 'torch.distributed did not import correctly, please use a PyTorch version with support.'
     if use_horovod:
         assert hvd is not None, 'Please install horovod'
         if gather_with_grad:

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -1,5 +1,38 @@
+from typing import Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torchvision.transforms.functional as F
+
+
 from torchvision.transforms import Normalize, Compose, RandomResizedCrop, InterpolationMode, ToTensor, Resize, \
     CenterCrop
+
+
+class ResizeMaxSize(nn.Module):
+
+    def __init__(self, max_size, interpolation=InterpolationMode.BICUBIC, fn='max', fill=0):
+        super().__init__()
+        if not isinstance(max_size, int):
+            raise TypeError(f"Size should be int. Got {type(max_size)}")
+        self.max_size = max_size
+        self.interpolation = interpolation
+        self.fn = min if fn == 'min' else min
+        self.fill = fill
+
+    def forward(self, img):
+        if isinstance(img, torch.Tensor):
+            height, width = img.shape[:2]
+        else:
+            width, height = img.size
+        scale = self.max_size / float(max(height, width))
+        if scale != 1.0:
+            new_size = tuple(round(dim * scale) for dim in (height, width))
+            img = F.resize(img, new_size, self.interpolation)
+            pad_h = self.max_size - new_size[0]
+            pad_w = self.max_size - new_size[1]
+            img = F.pad(img, padding=[pad_w//2, pad_h//2, pad_w - pad_w//2, pad_h - pad_h//2], fill=self.fill)
+        return img
 
 
 def _convert_to_rgb(image):
@@ -9,9 +42,17 @@ def _convert_to_rgb(image):
 def image_transform(
         image_size: int,
         is_train: bool,
-        mean=(0.48145466, 0.4578275, 0.40821073),
-        std=(0.26862954, 0.26130258, 0.27577711)
+        mean: Optional[Tuple[float, ...]] = None,
+        std: Optional[Tuple[float, ...]] = None,
+        resize_longest_max: bool = False,
+        fill_color: int = 0,
 ):
+    mean = mean or (0.48145466, 0.4578275, 0.40821073)  # OpenAI dataset mean
+    std = std or (0.26862954, 0.26130258, 0.27577711)  # OpenAI dataset std
+    if isinstance(image_size, (list, tuple)) and image_size[0] == image_size[1]:
+        # for square size, pass size as int so that Resize() uses aspect preserving shortest edge
+        image_size = image_size[0]
+
     normalize = Normalize(mean=mean, std=std)
     if is_train:
         return Compose([
@@ -21,10 +62,18 @@ def image_transform(
             normalize,
         ])
     else:
-        return Compose([
-            Resize(image_size, interpolation=InterpolationMode.BICUBIC),
-            CenterCrop(image_size),
+        if resize_longest_max:
+            transforms = [
+                ResizeMaxSize(image_size, fill=fill_color)
+            ]
+        else:
+            transforms = [
+                Resize(image_size, interpolation=InterpolationMode.BICUBIC),
+                CenterCrop(image_size),
+            ]
+        transforms.extend([
             _convert_to_rgb,
             ToTensor(),
             normalize,
         ])
+        return Compose(transforms)

--- a/src/open_clip/utils.py
+++ b/src/open_clip/utils.py
@@ -1,3 +1,6 @@
+from itertools import repeat
+import collections.abc
+
 from torch import nn as nn
 from torchvision.ops.misc import FrozenBatchNorm2d
 
@@ -39,3 +42,19 @@ def freeze_batch_norm_2d(module, module_match={}, name=''):
             if new_child is not child:
                 res.add_module(child_name, new_child)
     return res
+
+
+# From PyTorch internals
+def _ntuple(n):
+    def parse(x):
+        if isinstance(x, collections.abc.Iterable):
+            return x
+        return tuple(repeat(x, n))
+    return parse
+
+
+to_1tuple = _ntuple(1)
+to_2tuple = _ntuple(2)
+to_3tuple = _ntuple(3)
+to_4tuple = _ntuple(4)
+to_ntuple = lambda n, x: _ntuple(n)(x)

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -239,9 +239,9 @@ class detshuffle2(wds.PipelineStage):
             epoch = self.epoch
         rng = random.Random()
         if self.seed < 0:
-            seed = (pytorch_worker_seed(), epoch)
+            seed = pytorch_worker_seed() + epoch
         else:
-            seed = (self.seed, epoch)
+            seed = self.seed + epoch
         rng.seed(seed)
         print(f'detshuffle epoch: {epoch}, seed: {seed}')  # FIXME temporary debug print
         return _shuffle(src, self.bufsize, self.initial, rng)
@@ -282,7 +282,7 @@ class ResampledShards2(IterableDataset):
             self.epoch += 1
             epoch = self.epoch
         if self.deterministic:
-            seed = (self.worker_seed(), epoch)
+            seed = self.worker_seed() + epoch
         else:
             seed = (self.worker_seed(), epoch, os.getpid(), time.time())
         self.rng.seed(seed)

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -243,7 +243,6 @@ class detshuffle2(wds.PipelineStage):
         else:
             seed = self.seed + epoch
         rng.seed(seed)
-        print(f'detshuffle epoch: {epoch}, seed: {seed}')  # FIXME temporary debug print
         return _shuffle(src, self.bufsize, self.initial, rng)
 
 

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -90,9 +90,10 @@ def get_dataset_size(shards):
     else:
         total_size = None  # num samples undefined
         # some common dataset sizes (at time of authors last download)
-        # cc3m-train: 2905954
-        # cc12m: 10968539
-        # LAION-400m: 407332084
+        # CC3M (train): 2905954
+        # CC12M: 10968539
+        # LAION-400M: 407332084
+        # LAION-2B (english): 2170337258
     num_shards = len(shards_list)
     return total_size, num_shards
 
@@ -339,6 +340,8 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False):
 
     dataset = wds.DataPipeline(*pipeline)
     if is_train:
+        if not resampled:
+            assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
         # roll over and repeat a few samples to get same number of full batches on each node
         round_fn = math.floor if floor else math.ceil
         global_batch_size = args.batch_size * args.world_size

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -4,7 +4,10 @@ import logging
 import math
 import os
 import random
+import sys
+import time
 from dataclasses import dataclass
+from multiprocessing import Value
 
 import braceexpand
 import numpy as np
@@ -12,11 +15,11 @@ import pandas as pd
 import torch
 import torchvision.datasets as datasets
 import webdataset as wds
-from webdataset.tariterators import base_plus_ext, url_opener, tar_file_expander, valid_sample
 from PIL import Image
-from torch.utils.data import Dataset, DataLoader, SubsetRandomSampler
+from torch.utils.data import Dataset, DataLoader, SubsetRandomSampler, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
-
+from webdataset.filters import _shuffle
+from webdataset.tariterators import base_plus_ext, url_opener, tar_file_expander, valid_sample
 
 try:
     import horovod.torch as hvd
@@ -45,10 +48,28 @@ class CsvDataset(Dataset):
         return images, texts
 
 
+class SharedEpoch:
+    def __init__(self, epoch: int = 0):
+        self.shared_epoch = Value('i', epoch)
+
+    def set_value(self, epoch):
+        self.shared_epoch.value = epoch
+
+    def get_value(self):
+        return self.shared_epoch.value
+
+
 @dataclass
 class DataInfo:
     dataloader: DataLoader
-    sampler: DistributedSampler
+    sampler: DistributedSampler = None
+    shared_epoch: SharedEpoch = None
+
+    def set_epoch(self, epoch):
+        if self.shared_epoch is not None:
+            self.shared_epoch.set_value(epoch)
+        if self.sampler is not None and isinstance(self.sampler, DistributedSampler):
+            self.sampler.set_epoch(epoch)
 
 
 def preprocess_txt(text):
@@ -119,7 +140,7 @@ def get_imagenet(args, preprocess_fns, split):
         sampler=sampler,
     )
 
-    return DataInfo(dataloader, sampler)
+    return DataInfo(dataloader=dataloader, sampler=sampler)
 
 
 def count_samples(dataloader):
@@ -184,9 +205,83 @@ _SAMPLE_SHUFFLE_SIZE = 5000
 _SAMPLE_SHUFFLE_INITIAL = 1000
 
 
-def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
+class detshuffle2(wds.PipelineStage):
+    def __init__(
+            self,
+            bufsize=1000,
+            initial=100,
+            seed=0,
+            epoch=-1
+    ):
+        self.bufsize = bufsize
+        self.initial = initial
+        self.seed = seed
+        self.epoch = epoch
+
+    def run(self, src):
+        if isinstance(self.epoch, SharedEpoch):
+            epoch = self.epoch.get_value()
+        else:
+            # NOTE: this is epoch tracking is problematic in a multiprocess (dataloader workers or train)
+            # situation as different workers may wrap at different times (or not at all).
+            self.epoch += 1
+            epoch = self.epoch
+        rng = random.Random()
+        rng.seed((self.seed, epoch))
+        print(f'detshuffle epoch: {epoch}, seed: {self.seed}')  # FIXME temporary debug print
+        return _shuffle(src, self.bufsize, self.initial, rng)
+
+
+class ResampledShards2(IterableDataset):
+    """An iterable dataset yielding a list of urls."""
+
+    def __init__(
+        self,
+        urls,
+        nshards=sys.maxsize,
+        worker_seed=None,
+        deterministic=False,
+        epoch=-1,
+    ):
+        """Sample shards from the shard list with replacement.
+
+        :param urls: a list of URLs as a Python list or brace notation string
+        """
+        super().__init__()
+        urls = wds.shardlists.expand_urls(urls)
+        self.urls = urls
+        assert isinstance(self.urls[0], str)
+        self.nshards = nshards
+        self.rng = random.Random()
+        self.worker_seed = (
+            wds.utils.pytorch_worker_seed if worker_seed is None else worker_seed
+        )
+        self.deterministic = deterministic
+        self.epoch = epoch
+
+    def __iter__(self):
+        """Return an iterator over the shards."""
+        if isinstance(self.epoch, SharedEpoch):
+            epoch = self.epoch.get_value()
+        else:
+            # NOTE: this is epoch tracking is problematic in a multiprocess (dataloader workers or train)
+            # situation as different workers may wrap at different times (or not at all).
+            self.epoch += 1
+            epoch = self.epoch
+        if self.deterministic:
+            seed = (self.worker_seed(), epoch)
+        else:
+            seed = (self.worker_seed(), epoch, os.getpid(), time.time())
+        self.rng.seed(seed)
+        print(f'resampled epoch: {epoch}, seed: {seed}')  # FIXME temporary debug print
+        for _ in range(self.nshards):
+            yield dict(url=self.rng.choice(self.urls))
+
+
+def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False):
     input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
+    resampled = getattr(args, 'dataset_resampled', False) and is_train
 
     num_samples, num_shards = get_dataset_size(input_shards)
     if not num_samples:
@@ -199,18 +294,26 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
         else:
             num_samples = args.val_num_samples or 0  # eval will just exhaust the iterator if not specified
 
-    pipeline = [wds.SimpleShardList(input_shards)]
+    shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
+    if resampled:
+        pipeline = [ResampledShards2(input_shards, deterministic=True, epoch=shared_epoch)]
+    else:
+        pipeline = [wds.SimpleShardList(input_shards)]
+
     # at this point we have an iterator over all the shards
     if is_train:
+        if not resampled:
+            pipeline.extend([
+                detshuffle2(
+                    bufsize=_SHARD_SHUFFLE_SIZE,
+                    initial=_SHARD_SHUFFLE_INITIAL,
+                    seed=args.seed,
+                    epoch=shared_epoch,
+                ),
+                wds.split_by_node,
+                wds.split_by_worker,
+            ])
         pipeline.extend([
-            wds.detshuffle(
-                bufsize=_SHARD_SHUFFLE_SIZE,
-                initial=_SHARD_SHUFFLE_INITIAL,
-                seed=args.seed,
-                epoch=epoch - 1,
-            ),
-            wds.split_by_node,
-            wds.split_by_worker,
             # at this point, we have an iterator over the shards assigned to each worker at each node
             tarfile_to_samples_nothrow,  # wds.tarfile_to_samples(handler=log_and_continue),
             wds.shuffle(
@@ -218,7 +321,6 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
                 initial=_SAMPLE_SHUFFLE_INITIAL,
                 rng=random.Random(args.seed),
             ),
-            #wds.repeatedly,  # FIXME determine if this is beneficial
         ])
     else:
         pipeline.extend([
@@ -238,10 +340,11 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
     dataset = wds.DataPipeline(*pipeline)
     if is_train:
         # roll over and repeat a few samples to get same number of full batches on each node
+        round_fn = math.floor if floor else math.ceil
         global_batch_size = args.batch_size * args.world_size
-        num_batches = math.ceil(num_samples / global_batch_size)
+        num_batches = round_fn(num_samples / global_batch_size)
         num_workers = max(1, args.workers)
-        num_worker_batches = math.ceil(num_batches / num_workers)  # per dataloader worker
+        num_worker_batches = round_fn(num_batches / num_workers)  # per dataloader worker
         num_batches = num_worker_batches * num_workers
         num_samples = num_batches * global_batch_size
         dataset = dataset.with_epoch(num_worker_batches)  # each worker is iterating over this
@@ -254,8 +357,6 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
         batch_size=None,
         shuffle=False,
         num_workers=args.workers,
-        # FIXME detshuffle uses same seed each epoch unless workers are persistent
-        # this seems like a WDS bug, currently waiting for clarification
         persistent_workers=True,
     )
 
@@ -277,7 +378,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
     dataloader.num_batches = num_batches
     dataloader.num_samples = num_samples
 
-    return DataInfo(dataloader, None)
+    return DataInfo(dataloader=dataloader, shared_epoch=shared_epoch)
 
 
 def get_csv_dataset(args, preprocess_fn, is_train, epoch=0):

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -282,11 +282,8 @@ class ResampledShards2(IterableDataset):
             self.epoch += 1
             epoch = self.epoch
         if self.deterministic:
-            seed = self.worker_seed() + epoch
-        else:
-            seed = (self.worker_seed(), epoch, os.getpid(), time.time())
-        self.rng.seed(seed)
-        print(f'resampled epoch: {epoch}, seed: {seed}')  # FIXME temporary debug print
+            # reset seed w/ epoch if deterministic, worker seed should be deterministic due to arg.seed
+            self.rng.seed(self.worker_seed() + epoch)
         for _ in range(self.nshards):
             yield dict(url=self.rng.choice(self.urls))
 

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -112,6 +112,7 @@ def main():
     else:
         logging.info(f'Running with a single process. Device {args.device}.')
 
+    random_seed(args.seed, 0)
     model, preprocess_train, preprocess_val = create_model_and_transforms(
         args.model,
         args.pretrained,
@@ -121,6 +122,7 @@ def main():
         force_quick_gelu=args.force_quick_gelu,
         pretrained_image=args.pretrained_image,
     )
+    random_seed(args.seed, args.rank)
 
     if args.trace:
         model = trace_model(model, batch_size=args.batch_size, device=device)

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -43,6 +43,12 @@ def parse_args():
         help="Which type of dataset to process."
     )
     parser.add_argument(
+        "--dataset-resampled",
+        default=False,
+        action="store_true",
+        help="Whether to use sampling with replacement for webdataset shard selection."
+    )
+    parser.add_argument(
         "--csv-separator",
         type=str,
         default="\t",
@@ -91,7 +97,7 @@ def parse_args():
         help="Optional identifier for the experiment when storing logs. Otherwise use current time.",
     )
     parser.add_argument(
-        "--workers", type=int, default=1, help="Number of workers per GPU."
+        "--workers", type=int, default=1, help="Number of dataloader workers per GPU."
     )
     parser.add_argument(
         "--batch-size", type=int, default=64, help="Batch size per GPU."

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -279,7 +279,7 @@ def parse_args():
         help="Don't set device index from local rank (when CUDA_VISIBLE_DEVICES restricted to one per proc)."
     )
     parser.add_argument(
-        "--seed", type=int, default=4242, help="Default random seed."
+        "--seed", type=int, default=0, help="Default random seed."
     )
     args = parser.parse_args()
 

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -57,9 +57,8 @@ def train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, tb_w
         world_size=args.world_size,
         use_horovod=args.horovod)
 
-    dataloader, sampler = data['train'].dataloader, data['train'].sampler
-    if args.distributed and sampler is not None:
-        sampler.set_epoch(epoch)
+    data['train'].set_epoch(epoch)  # set epoch in process safe manner via sampler or shared_epoch
+    dataloader = data['train'].dataloader
     num_batches_per_epoch = dataloader.num_batches
     sample_digits = math.ceil(math.log(dataloader.num_samples + 1, 10))
 


### PR DESCRIPTION
WIP set of changes that reflect what's being used in current LAION training runs to support fine-tune, and possibly alternate epoch handling to handle case where maximum job runtime < full epoch of samples.

Done:
* support to resize (interpolate) the abs position embedding for default ViT impl, will allow fine tune at different resolutions
* support WDS 'ResampledShard', sample shards with replacement in each train process / dataloader worker instead of shuffling them across workers w/ a deterministic (epoch based) seed. This will allow resume in the middle of an epoch but may have an impact on training results
* improve epoch synchronization across worker processes, the ball was really dropped here for latest WDS impl 0.2.x and I don't see a way to make their scheme work across several corner cases. Implemented a custom multiprocessing.Value based impl that seems sound 

TODO:
* to go with resampled, need to add option to save checkpoints at step intervals instead of epoch transitions
