### PR TITLE
support a sampling strategy for multiple training datasets

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -184,8 +184,11 @@ _SAMPLE_SHUFFLE_SIZE = 5000
 _SAMPLE_SHUFFLE_INITIAL = 1000
 
 
-def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
-    input_shards = args.train_data if is_train else args.val_data
+def get_wds_dataset(args, preprocess_img, is_train, epoch=0, filepath=None):
+    if filepath:
+        input_shards = filepath
+    else:
+        input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
 
     num_samples, num_shards = get_dataset_size(input_shards)
@@ -280,8 +283,11 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0):
     return DataInfo(dataloader, None)
 
 
-def get_csv_dataset(args, preprocess_fn, is_train, epoch=0):
-    input_filename = args.train_data if is_train else args.val_data
+def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, filepath=None):
+    if filepath:
+        input_filename = filepath
+    else:
+        input_filename = args.train_data if is_train else args.val_data
     assert input_filename
     dataset = CsvDataset(
         input_filename,
@@ -331,8 +337,15 @@ def get_data(args, preprocess_fns, epoch=0):
     data = {}
 
     if args.train_data:
-        data["train"] = get_dataset_fn(args.train_data, args.dataset_type)(
-            args, preprocess_train, is_train=True, epoch=epoch)
+        train_data_list = args.train_data.split(', ')
+        if len(train_data_list) > 1:
+            data["train"] = []
+            for train_data in train_data_list:
+                data["train"].append(get_dataset_fn(train_data, args.dataset_type)(
+                args, preprocess_train, is_train=True, epoch=epoch, filepath=train_data))
+        else:
+            data["train"] = get_dataset_fn(args.train_data, args.dataset_type)(
+                args, preprocess_train, is_train=True, epoch=epoch)
 
     if args.val_data:
         data["val"] = get_dataset_fn(args.val_data, args.dataset_type)(

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -206,6 +206,12 @@ def parse_args():
         help="Force use of QuickGELU activation for non-OpenAI transformer models.",
     )
     parser.add_argument(
+        "--debias-sample",
+        default=False,
+        action='store_true',
+        help="Enable debias sampling.",
+    )
+    parser.add_argument(
         "--torchscript",
         default=False,
         action='store_true',

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -143,6 +143,136 @@ def train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, tb_w
     # end for
 
 
+def train_one_epoch_debias_sample(model, data, epoch, optimizer, scaler, scheduler, args, tb_writer=None):
+    device = torch.device(args.device)
+    autocast = torch.cuda.amp.autocast if args.precision == 'amp' else suppress
+
+    model.train()
+    loss = ClipLoss(
+        local_loss=args.local_loss,
+        gather_with_grad=args.gather_with_grad,
+        cache_labels=True,
+        rank=args.rank,
+        world_size=args.world_size,
+        use_horovod=args.horovod)
+
+    # checking if multiple datasets are used.
+    assert isinstance(data['train'], list)
+    assert len(data['train']) > 1
+
+    # create lists of dataloaders, dataiters, and samplers for multiple datasets
+    num_datasets = len(data['train'])
+    dataloaders = [dataset.dataloader for dataset in data['train']]
+    dataiters = [iter(dataloader) for dataloader in dataloaders]
+    samplers = [dataset.sampler for dataset in data['train']]
+
+    if args.distributed and samplers is not None:
+        for sampler in samplers:
+            sampler.set_epoch(epoch)
+
+    num_batches_per_epoch = sum([dataloader.num_batches for dataloader in dataloaders])
+    num_samples_per_epoch = sum([dataloader.num_samples for dataloader in dataloaders])
+    # calculate sampling weight according to num_samples of multiple datasets
+    sample_weights = np.array([float(dataloader.num_samples) / num_samples_per_epoch for dataloader in dataloaders])
+    
+    sample_digits = math.ceil(math.log(num_samples_per_epoch + 1, 10))
+
+    loss_m = AverageMeter()
+    batch_time_m = AverageMeter()
+    data_time_m = AverageMeter()
+    end = time.time()
+
+    for i in range(num_batches_per_epoch):
+        # set random seed for sampling from the same dataset.
+        stable_random_seed = int(time.time())
+        np.random.seed(stable_random_seed + i)
+        # sample a dataset according to sample_weights
+        iter_index = np.random.choice(range(num_datasets), p=sample_weights)
+        # generate training image-text pairs from the sampled dataset
+        try:
+            data_iter = dataiters[iter_index]
+            batch = next(data_iter)
+        except StopIteration:
+            # refresh dataiter if necessary
+            dataiters[iter_index] = iter(dataloaders[iter_index])
+            data_iter = dataiters[iter_index]
+            batch = next(data_iter)
+
+        step = num_batches_per_epoch * epoch + i
+        scheduler(step)
+
+        images, texts = batch
+        images = images.to(device=device, non_blocking=True)
+        texts = texts.to(device=device, non_blocking=True)
+
+        data_time_m.update(time.time() - end)
+        optimizer.zero_grad()
+
+        with autocast():
+            image_features, text_features, logit_scale = model(images, texts)
+            total_loss = loss(image_features, text_features, logit_scale)
+
+        if scaler is not None:
+            scaler.scale(total_loss).backward()
+            if args.horovod:
+                optimizer.synchronize()
+                scaler.unscale_(optimizer)
+                with optimizer.skip_synchronize():
+                    scaler.step(optimizer)
+            else:
+                scaler.step(optimizer)
+            scaler.update()
+        else:
+            total_loss.backward()
+            optimizer.step()
+
+        # Note: we clamp to 4.6052 = ln(100), as in the original paper.
+        with torch.no_grad():
+            unwrap_model(model).logit_scale.clamp_(0, math.log(100))
+
+        batch_time_m.update(time.time() - end)
+        end = time.time()
+        batch_count = i + 1
+        if is_master(args) and (i % 100 == 0 or batch_count == num_batches_per_epoch):
+            batch_size = len(images)
+            num_samples = batch_count * batch_size * args.world_size
+            samples_per_epoch = num_samples_per_epoch
+            percent_complete = 100.0 * batch_count / num_batches_per_epoch
+
+            # NOTE loss is coarsely sampled, just master node and per log update
+            loss_m.update(total_loss.item(), batch_size)
+            logit_scale_scalar = logit_scale.item()
+            logging.info(
+                f"Train Epoch: {epoch} [{num_samples:>{sample_digits}}/{samples_per_epoch} ({percent_complete:.0f}%)] "
+                f"Loss: {loss_m.val:#.5g} ({loss_m.avg:#.4g}) "
+                f"Data (t): {data_time_m.avg:.3f} "
+                f"Batch (t): {batch_time_m.avg:.3f} "
+                f"LR: {optimizer.param_groups[0]['lr']:5f} "
+                f"Logit Scale: {logit_scale_scalar:.3f}"
+            )
+
+            # Save train loss / etc. Using non avg meter values as loggers have their own smoothing
+            log_data = {
+                "loss": loss_m.val,
+                "data_time": data_time_m.val,
+                "batch_time": batch_time_m.val,
+                "scale":  logit_scale_scalar,
+                "lr": optimizer.param_groups[0]["lr"]
+            }
+            for name, val in log_data.items():
+                name = "train/" + name
+                if tb_writer is not None:
+                    tb_writer.add_scalar(name, val, step)
+                if args.wandb:
+                    assert wandb is not None, 'Please install wandb.'
+                    wandb.log({name: val, 'step': step})
+
+            # resetting batch / data time meters per log window
+            batch_time_m.reset()
+            data_time_m.reset()
+    # end for
+
+
 def evaluate(model, data, epoch, args, tb_writer=None):
     metrics = {}
     if not is_master(args):


### PR DESCRIPTION
Proposing the debiased sampling method proposed in [the ZeroVL paper](https://arxiv.org/abs/2112.09331). When training multiple datasets, the debiased sampling improves the accuracy of CLIP model. It includes a new flag:
* --debias-sample, a boolean flag that enables the debiased sampling method

## Introduction of Debiased Sampling
![image](https://user-images.githubusercontent.com/97945643/172780549-94b16e62-9973-491e-8c76-5ae84b69c574.png)
As shown in Fig2, random sampling is the most intuitive sampling method, which randomly constructs training batches with all available data. However, as shown in Fig3, random sampling leads to biased feature distributions on both image and text modalities. 
Debiased sampling ensures instances within each batch come from the same dataset. Training with debiased sampling improves the quality of learned representations, and contributes to better results on many downstream tasks.

## Experiments on sampling methods
We use two datasets, CC3M and SBU, to show the improvements of debiased sampling.

### Experiment1: Random Sampling
#### 1. Setting & Acc
dataset: CC3M + SBU (2.79M + 0.86M)
batchsize: 2048 (256 per GPU, 8 V100 32GB)
learning rate: 1e-3
weight decay: 0.1
sampling: random
zero-shot acc on ImageNet: **top1 21.36, top5 40.98**

#### 2. Training script
```bash
torchrun --nproc_per_node 8 -m training.main 
    --train-data "/data/cc3m/cc3m_sbu_train_anno.csv" \
    --dataset-type auto \
    --batch-size 256 \
    --precision amp \
    --workers 4 \
    --imagenet-val "/data/ILSVRC/Data/CLS-LOC/val" \
    --csv-separator , \
    --lr=1e-3 \
    --wd=0.1
```
'/data/cc3m/cc3m_sbu_train_anno.csv' contains all samples from CC3M and SBU. 

#### 3. Log
[cc3m+sbu+random_sample.log](https://github.com/mlfoundations/open_clip/files/8867767/cc3m%2Bsbu%2Brandom_sample.log)


### Experiment2: Debiased Sampling
#### 1. Setting
dataset: CC3M + SBU (2.79M + 0.86M)
batchsize: 2048 (256 per GPU, 8 V100 32GB)
learning rate: 1e-3
weight decay: 0.1
sampling: debias
zero-shot acc on ImageNet: **top1 22.33, top5 42.29**

#### 2. Training script
```bash
torchrun --nproc_per_node 8 -m training.main 
    --train-data "/data/cc3m/cc3m_train_anno.csv, /data/sbu/sbu_train_anno.csv" \
    --dataset-type auto \
    --batch-size 256 \
    --precision amp \
    --workers 4 \
    --imagenet-val "/data/ILSVRC/Data/CLS-LOC/val" \
    --csv-separator , \
    --lr=1e-3 \
    --wd=0.1 \
    --debias-sample
```

#### 3. Log
[cc3m+sbu+debias_sample.log](https://github.com/mlfoundations/open_clip/files/8867768/cc3m%2Bsbu%2Bdebias_sample.log)

