### PR TITLE
Support decoupled gradient accumulation

### DIFF
--- a/src/open_clip/__init__.py
+++ b/src/open_clip/__init__.py
@@ -1,5 +1,5 @@
 from .factory import list_models, create_model, create_model_and_transforms, add_model_config
-from .loss import ClipLoss
+from .loss import ClipLoss, DGAClipLoss
 from .model import CLIP, CLIPTextCfg, CLIPVisionCfg, convert_weights_to_fp16, trace_model
 from .openai import load_openai_model, list_openai_models
 from .pretrained import list_pretrained, list_pretrained_tag_models, list_pretrained_model_tags,\

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -29,7 +29,7 @@ from training.distributed import is_master, init_distributed_device, world_info_
 from training.logger import setup_logging
 from training.params import parse_args
 from training.scheduler import cosine_lr
-from training.train import train_one_epoch, evaluate, train_one_epoch_dga
+from training.train import train_one_epoch, evaluate
 
 
 def random_seed(seed=42, rank=0):
@@ -250,10 +250,7 @@ def main():
         if is_master(args):
             logging.info(f'Start epoch {epoch}')
 
-        if args.decoupled_grad_accu:
-            train_one_epoch_dga(model, data, epoch, optimizer, scaler, scheduler, args, writer)
-        else:
-            train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, writer)
+        train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, writer)
         completed_epoch = epoch + 1
 
         if any(v in data for v in ('val', 'imagenet-val', 'imagenet-v2')):

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -29,7 +29,7 @@ from training.distributed import is_master, init_distributed_device, world_info_
 from training.logger import setup_logging
 from training.params import parse_args
 from training.scheduler import cosine_lr
-from training.train import train_one_epoch, evaluate
+from training.train import train_one_epoch, evaluate, train_one_epoch_dga
 
 
 def random_seed(seed=42, rank=0):
@@ -250,7 +250,10 @@ def main():
         if is_master(args):
             logging.info(f'Start epoch {epoch}')
 
-        train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, writer)
+        if args.decoupled_grad_accu:
+            train_one_epoch_dga(model, data, epoch, optimizer, scaler, scheduler, args, writer)
+        else:
+            train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, writer)
         completed_epoch = epoch + 1
 
         if any(v in data for v in ('val', 'imagenet-val', 'imagenet-v2')):

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -97,6 +97,9 @@ def parse_args():
         "--batch-size", type=int, default=64, help="Batch size per GPU."
     )
     parser.add_argument(
+        "--batch-size-train", type=int, default=64, help="Batch size per GPU per sub-iteration. (decoupled grad accu)"
+    )
+    parser.add_argument(
         "--epochs", type=int, default=32, help="Number of epochs to train for."
     )
     parser.add_argument("--lr", type=float, default=None, help="Learning rate.")
@@ -186,6 +189,12 @@ def parse_args():
         default=False,
         action='store_true',
         help="Enable gradient checkpointing.",
+    )
+    parser.add_argument(
+        "--decoupled-grad-accu",
+        default=False,
+        action='store_true',
+        help="Enable decoupled gradient accumulation.",
     )
     parser.add_argument(
         "--local-loss",

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -5,6 +5,7 @@ import os
 import time
 from contextlib import suppress
 
+import random
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -35,6 +36,14 @@ class AverageMeter(object):
         self.sum += val * n
         self.count += n
         self.avg = self.sum / self.count
+
+
+def setup_seed(seed):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.backends.cudnn.deterministic = True
 
 
 def unwrap_model(model):
@@ -94,6 +103,187 @@ def train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, tb_w
             scaler.update()
         else:
             total_loss.backward()
+            optimizer.step()
+
+        # Note: we clamp to 4.6052 = ln(100), as in the original paper.
+        with torch.no_grad():
+            unwrap_model(model).logit_scale.clamp_(0, math.log(100))
+
+        batch_time_m.update(time.time() - end)
+        end = time.time()
+        batch_count = i + 1
+        if is_master(args) and (i % 100 == 0 or batch_count == num_batches_per_epoch):
+            batch_size = len(images)
+            num_samples = batch_count * batch_size * args.world_size
+            samples_per_epoch = dataloader.num_samples
+            percent_complete = 100.0 * batch_count / num_batches_per_epoch
+
+            # NOTE loss is coarsely sampled, just master node and per log update
+            loss_m.update(total_loss.item(), batch_size)
+            logit_scale_scalar = logit_scale.item()
+            logging.info(
+                f"Train Epoch: {epoch} [{num_samples:>{sample_digits}}/{samples_per_epoch} ({percent_complete:.0f}%)] "
+                f"Loss: {loss_m.val:#.5g} ({loss_m.avg:#.4g}) "
+                f"Data (t): {data_time_m.avg:.3f} "
+                f"Batch (t): {batch_time_m.avg:.3f} "
+                f"LR: {optimizer.param_groups[0]['lr']:5f} "
+                f"Logit Scale: {logit_scale_scalar:.3f}"
+            )
+
+            # Save train loss / etc. Using non avg meter values as loggers have their own smoothing
+            log_data = {
+                "loss": loss_m.val,
+                "data_time": data_time_m.val,
+                "batch_time": batch_time_m.val,
+                "scale":  logit_scale_scalar,
+                "lr": optimizer.param_groups[0]["lr"]
+            }
+            for name, val in log_data.items():
+                name = "train/" + name
+                if tb_writer is not None:
+                    tb_writer.add_scalar(name, val, step)
+                if args.wandb:
+                    assert wandb is not None, 'Please install wandb.'
+                    wandb.log({name: val, 'step': step})
+
+            # resetting batch / data time meters per log window
+            batch_time_m.reset()
+            data_time_m.reset()
+    # end for
+
+
+def train_one_epoch_dga(model, data, epoch, optimizer, scaler, scheduler, args, tb_writer=None):
+    device = torch.device(args.device)
+    autocast = torch.cuda.amp.autocast if args.precision == 'amp' else suppress
+
+    model.train()
+
+    dataloader, sampler = data['train'].dataloader, data['train'].sampler
+    if args.distributed and sampler is not None:
+        sampler.set_epoch(epoch)
+    num_batches_per_epoch = dataloader.num_batches
+    sample_digits = math.ceil(math.log(dataloader.num_samples + 1, 10))
+
+    loss_m = AverageMeter()
+    batch_time_m = AverageMeter()
+    data_time_m = AverageMeter()
+    end = time.time()
+
+    for i, batch in enumerate(dataloader):
+        # generate and setup random seed, thus forwarding a sample twice will produce the same embedding
+        stable_random_seed = int(time.time() * 1000 % 1000000)
+        setup_seed(stable_random_seed + args.rank)
+
+        step = num_batches_per_epoch * epoch + i
+        scheduler(step)
+
+        images, texts = batch
+        images = images.to(device=device, non_blocking=True)
+        texts = texts.to(device=device, non_blocking=True)
+
+        data_time_m.update(time.time() - end)
+        optimizer.zero_grad()
+
+        # first time forward without grad 
+        with torch.no_grad():
+            image_embeddings_local, text_embeddings_local = [], []
+
+            for _idx_l in range(0, args.batch_size, args.batch_size_train):
+                _images = images[_idx_l: _idx_l + args.batch_size_train]
+                _texts = texts[_idx_l: _idx_l + args.batch_size_train]
+
+                with autocast():
+                    # (i', d), (t', d)
+                    _image_embeddings, _text_embeddings, logit_scale = model(_images, _texts)
+
+                image_embeddings_local.append(_image_embeddings)
+                text_embeddings_local.append(_text_embeddings)
+            
+            # (i, d), (t, d)
+            image_embeddings_local = torch.cat(image_embeddings_local, dim = 0)
+            text_embeddings_local = torch.cat(text_embeddings_local, dim = 0)
+            
+            logit_scale_sqrt = torch.sqrt(logit_scale)
+
+            # (i, d)
+            image_embeddings_global = torch.cat(torch.distributed.nn.all_gather(image_embeddings_local), dim=0)
+            # (t, d)
+            text_embeddings_global = torch.cat(torch.distributed.nn.all_gather(text_embeddings_local), dim=0)
+    
+            s_i2t_nm = image_embeddings_global @ text_embeddings_local.T
+            s_i2t_mn = image_embeddings_local @ text_embeddings_global.T
+
+            # (i, t'), (i', t)
+            s_i2t_nm *= logit_scale
+            s_i2t_mn *= logit_scale
+            
+            # (i), (t)
+            targets_i2t = torch.arange(args.batch_size * args.rank, args.batch_size * (args.rank + 1), device=args.device)
+            targets_t2i = torch.arange(args.batch_size * args.rank, args.batch_size * (args.rank + 1), device=args.device)
+
+            total_loss = 0.5 * (F.cross_entropy(s_i2t_mn, targets_i2t) + F.cross_entropy(s_i2t_nm.T, targets_t2i)).cpu()
+            
+            # (i'), (t')
+            s_i2t_esum_local = torch.sum(torch.exp(s_i2t_mn), dim = 1)
+            s_t2i_esum_local = torch.sum(torch.exp(s_i2t_nm.T), dim = 1)
+            
+            # (i), (t)
+            s_i2t_esum = torch.cat(torch.distributed.nn.all_gather(s_i2t_esum_local), dim=0).unsqueeze(dim = 1)
+            s_t2i_esum = torch.cat(torch.distributed.nn.all_gather(s_t2i_esum_local), dim=0).unsqueeze(dim = 1)
+
+            p_i2t_mn = torch.exp(s_i2t_mn) / s_i2t_esum[args.batch_size * args.rank: args.batch_size * (args.rank + 1), :]
+            p_t2i_nm = torch.exp(s_i2t_mn.T) / s_t2i_esum
+            left_I = (p_i2t_mn + p_t2i_nm.T) @ text_embeddings_global - text_embeddings_local * 2
+            
+            p_i2t_nm = torch.exp(s_i2t_nm) / s_i2t_esum
+            p_t2i_mn = torch.exp(s_i2t_nm.T) / s_t2i_esum[args.batch_size * args.rank: args.batch_size * (args.rank + 1), :]
+            left_T = (p_i2t_nm.T + p_t2i_mn) @ image_embeddings_global - image_embeddings_local * 2
+            
+            # (i, d) = (1) * ((i, t) @ (t, d))
+            left_I *= logit_scale_sqrt
+            left_T *= logit_scale_sqrt
+        
+        setup_seed(stable_random_seed + args.rank)
+
+        # second time forward with grad
+        for _idx_l in range(0, args.batch_size, args.batch_size_train):
+            _images = images[_idx_l: _idx_l + args.batch_size_train]
+            _texts = texts[_idx_l: _idx_l + args.batch_size_train]
+
+            with autocast():
+                # (i', d), (t', d)
+                _image_embeddings, _text_embeddings, logit_scale = model(_images, _texts)
+
+            # (i', d), (t', d)
+            _left_I = left_I[_idx_l: _idx_l + args.batch_size_train]
+            _left_T = left_T[_idx_l: _idx_l + args.batch_size_train]
+            
+            logit_scale_sqrt = torch.sqrt(logit_scale)
+
+            # (i')
+            loss_temp_i = _left_I * _image_embeddings
+            loss_temp_t = _left_T * _text_embeddings
+
+            loss_temp = (loss_temp_i + loss_temp_t).sum() / 2 / args.batch_size
+            loss_temp = loss_temp * logit_scale_sqrt
+            
+            # backward each sub-iteration
+            if scaler is not None:
+                scaler.scale(loss_temp).backward()
+            else:
+                loss_temp.backward()
+
+        # step each iteration
+        if scaler is not None:
+            if args.horovod:
+                optimizer.synchronize()
+                scaler.unscale_(optimizer)
+                with optimizer.skip_synchronize():
+                    scaler.step(optimizer)
+            else:
+                scaler.step(optimizer)
+            scaler.update()
+        else:
             optimizer.step()
 
         # Note: we clamp to 4.6052 = ln(100), as in the original paper.


### PR DESCRIPTION
Proposing the decoupled gradient accumulation~(DGA) method proposed in [the ZeroVL paper](https://arxiv.org/abs/2112.09331). DGA enables training CLIP model with a large batchsize but limited GPUs (e.g., 16,384 batchsize with 8V100 GPUs). It includes two new flags:
* --decoupled-grad-accu, a boolean flag that enables the decoupled gradient accumulation.
* --batch-size-train, a int flag that divides a large batch into several small sub-batches.

## Introduction of Decoupled Gradient Accumulation
![image](https://user-images.githubusercontent.com/97945643/172790405-6fa46fb3-1b6c-4512-b1ac-8368527e061d.png)
The gradient of CLIP loss is decoupled into two parts. One relates to stop-grad embeddings, and the other relates to with-grad embeddings. Thus, we can mimic the large batch training by twice forward. The first forward calculates the stop-grad part, and the second forward calculates the with-grad part and backwards. The decoupled formulation helps us train CLIP with extremely large batch size. 

### Usage:
```--batch-size``` denotes the large batch size we want to use on each GPU. 
```--batch-size-train``` denotes the small batch size that one GPU can hold. 

For instance, we can separate a large batch iteration into several small batch iterations, e.g., a batch of 8,192 samples could be divided to 4 sub-batches (each has 2048 samples and could be hold with limited GPUs). For the first forward, we can obtain the stop-grad part of the large batch~(8,192 samples). For the second forward, we can forward each sub-batch, and calculate(&backward) the correct gradient of the sub-batch.

To achieve this with **8 V100 GPUs (32GB)**, ```--batch-size=1024``` will train CLIP model with 8,192 (1024 x 8GPUs) batch size. ```--batch-size-train=256``` means each iteration will be divided into 4 (1024 / 256) sub-iterations. In each sub-iteration, the small batch size is 2048 (256 x 8GPUs), which can be hold by 8 V100 GPUs.

The drawback is DGA costs more training time. In our experiments, DGA costs 30-40% extra training time.

## Experiments on Decoupled Gradient Accumulation
We prove that training w/wo DGA achieves almost the same results.

### Experiment1: without DGA
#### 1. Setting & Acc
dataset: CC3M (2.79M)
batchsize: 1024 (128 per GPU, 8 V100 32GB)
learning rate: 1e-3
weight decay: 0.1
imagenet-zeroshot-val-top1: 0.1800

#### 2. Training script
```bash
torchrun --nproc_per_node 8 -m training.main 
    --train-data "/data/cc3m/cc3m_train_anno.csv" \
    --dataset-type auto \
    --batch-size 128 \
    --precision amp \
    --workers 4 \
    --imagenet-val "/data/ILSVRC/Data/CLS-LOC/val" \
    --csv-separator , \
    --lr=1e-3 \
    --wd=0.1
```

#### 3. Log
[cc3m.log](https://github.com/mlfoundations/open_clip/files/8868295/cc3m.log)


### Experiment2: with DGA
#### 1. Setting
dataset: CC3M (2.79M)
batchsize: 1024 (128 per GPU, 8 V100 32GB)
learning rate: 1e-3
weight decay: 0.1
imagenet-zeroshot-val-top1: 0.1791

#### 2. Training script
```bash
torchrun --nproc_per_node 8 -m training.main 
    --train-data "/data/cc3m/cc3m_train_anno.csv" \
    --dataset-type auto \
    --precision amp \
    --workers 4 \
    --imagenet-val "/data/ILSVRC/Data/CLS-LOC/val" \
    --csv-separator , \
    --lr=1e-3 \
    --wd=0.1 \
    --batch-size 128 \
    --batch-size-train 64 \
    --decoupled-grad-accu
```

#### 3. Log
[cc3m+dga.log](https://github.com/mlfoundations/open_clip/files/8868296/cc3m%2Bdga.log)

