### PR TITLE
Add checksum verification for pretrained model weights downloaded from mlfoundations github org

### DIFF
--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -130,6 +130,8 @@ def download_pretrained(url: str, root: str = os.path.expanduser("~/.cache/clip"
 
     if 'openaipublic' in url:
         expected_sha256 = url.split("/")[-2]
+    elif 'mlfoundations' in url:
+        expected_sha256 = os.path.splitext(filename)[0].split("-")[-1]
     else:
         expected_sha256 = ''
 
@@ -140,7 +142,7 @@ def download_pretrained(url: str, root: str = os.path.expanduser("~/.cache/clip"
 
     if os.path.isfile(download_target):
         if expected_sha256:
-            if hashlib.sha256(open(download_target, "rb").read()).hexdigest() == expected_sha256:
+            if hashlib.sha256(open(download_target, "rb").read()).hexdigest().startswith(expected_sha256):
                 return download_target
             else:
                 warnings.warn(f"{download_target} exists, but the SHA256 checksum does not match; re-downloading the file")
@@ -148,7 +150,7 @@ def download_pretrained(url: str, root: str = os.path.expanduser("~/.cache/clip"
             return download_target
 
     with urllib.request.urlopen(url) as source, open(download_target, "wb") as output:
-        with tqdm(total=int(source.info().get("Content-Length")), ncols=80, unit='iB', unit_scale=True) as loop:
+        with tqdm(total=int(source.headers.get("Content-Length")), ncols=80, unit='iB', unit_scale=True) as loop:
             while True:
                 buffer = source.read(8192)
                 if not buffer:
@@ -157,7 +159,7 @@ def download_pretrained(url: str, root: str = os.path.expanduser("~/.cache/clip"
                 output.write(buffer)
                 loop.update(len(buffer))
 
-    if expected_sha256 and hashlib.sha256(open(download_target, "rb").read()).hexdigest() != expected_sha256:
+    if expected_sha256 and not hashlib.sha256(open(download_target, "rb").read()).hexdigest().startswith(expected_sha256):
         raise RuntimeError(f"Model has been downloaded but the SHA256 checksum does not not match")
 
     return download_target

--- a/tests/test_download_pretrained.py
+++ b/tests/test_download_pretrained.py
@@ -1,0 +1,89 @@
+import hashlib
+import tempfile
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+from urllib3 import HTTPResponse
+from urllib3._collections import HTTPHeaderDict
+
+from open_clip.pretrained import download_pretrained
+
+
+class DownloadPretrainedTests(unittest.TestCase):
+
+    def create_response(self, data, status_code=200, content_type='application/octet-stream'):
+        fp = BytesIO(data)
+        headers = HTTPHeaderDict({
+            'Content-Type': content_type,
+            'Content-Length': str(len(data))
+        })
+        raw = HTTPResponse(fp, preload_content=False, headers=headers, status=status_code)
+        return raw
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_openaipublic(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()
+        urllib.request.urlopen.return_value = self.create_response(file_contents)
+        with tempfile.TemporaryDirectory() as root:
+            url = f'https://openaipublic.azureedge.net/clip/models/{expected_hash}/RN50.pt'
+            download_pretrained(url, root)
+        urllib.request.urlopen.assert_called_once()
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_openaipublic_corrupted(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()
+        urllib.request.urlopen.return_value = self.create_response(b'corrupted pretrained model')
+        with tempfile.TemporaryDirectory() as root:
+            url = f'https://openaipublic.azureedge.net/clip/models/{expected_hash}/RN50.pt'
+            with self.assertRaisesRegex(RuntimeError, r'checksum does not not match'):
+                download_pretrained(url, root)
+        urllib.request.urlopen.assert_called_once()
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_openaipublic_valid_cache(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()
+        urllib.request.urlopen.return_value = self.create_response(file_contents)
+        with tempfile.TemporaryDirectory() as root:
+            local_file = Path(root) / 'RN50.pt'
+            local_file.write_bytes(file_contents)
+            url = f'https://openaipublic.azureedge.net/clip/models/{expected_hash}/RN50.pt'
+            download_pretrained(url, root)
+        urllib.request.urlopen.assert_not_called()
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_openaipublic_corrupted_cache(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()
+        urllib.request.urlopen.return_value = self.create_response(file_contents)
+        with tempfile.TemporaryDirectory() as root:
+            local_file = Path(root) / 'RN50.pt'
+            local_file.write_bytes(b'corrupted pretrained model')
+            url = f'https://openaipublic.azureedge.net/clip/models/{expected_hash}/RN50.pt'
+            download_pretrained(url, root)
+        urllib.request.urlopen.assert_called_once()
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_mlfoundations(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()[:8]
+        urllib.request.urlopen.return_value = self.create_response(file_contents)
+        with tempfile.TemporaryDirectory() as root:
+            url = f'https://github.com/mlfoundations/download/v0.2-weights/rn50-quickgelu-{expected_hash}.pt'
+            download_pretrained(url, root)
+        urllib.request.urlopen.assert_called_once()
+
+    @patch('open_clip.pretrained.urllib')
+    def test_download_pretrained_from_mlfoundations_corrupted(self, urllib):
+        file_contents = b'pretrained model weights'
+        expected_hash = hashlib.sha256(file_contents).hexdigest()[:8]
+        urllib.request.urlopen.return_value = self.create_response(b'corrupted pretrained model')
+        with tempfile.TemporaryDirectory() as root:
+            url = f'https://github.com/mlfoundations/download/v0.2-weights/rn50-quickgelu-{expected_hash}.pt'
+            with self.assertRaisesRegex(RuntimeError, r'checksum does not not match'):
+                download_pretrained(url, root)
+        urllib.request.urlopen.assert_called_once()


### PR DESCRIPTION
Fixes #143 

## Tests output

```
$ PYTHONPATH=src python -m pytest tests

==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/fabio/workspaces/oss/open_clip
plugins: forked-1.4.0, xdist-2.5.0
collected 7 items                                                                                                                                                                            

tests/test_download_pretrained.py ......                                                                                                                                               [ 85%]
tests/test_simple.py .                                                                                                                                                                 [100%]

====================================================================================== warnings summary ======================================================================================
tests/test_download_pretrained.py::DownloadPretrainedTests::test_download_pretrained_from_openaipublic_corrupted_cache
  /home/fabio/workspaces/oss/open_clip/src/open_clip/pretrained.py:148: UserWarning: /tmp/tmpa9sx2lap/RN50.pt exists, but the SHA256 checksum does not match; re-downloading the file
    warnings.warn(f"{download_target} exists, but the SHA256 checksum does not match; re-downloading the file")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 7 passed, 1 warning in 10.21s ================================================================================

```
