### PR TITLE
wandb: initialize name to args.name

### DIFF
--- a/src/training/main.py
+++ b/src/training/main.py
@@ -240,6 +240,7 @@ def main():
         # you will have to configure this for your project!
         wandb.init(
             project="open-clip",
+            name=args.name,
             notes=args.wandb_notes,
             tags=[],
             config=vars(args),


### PR DESCRIPTION
seems this is strictly better:
worst case it's just as bad as random wandb name
best case you need to change nothing/less