### PR TITLE
Support distributed evaluation

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -362,9 +362,8 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False):
         dataset = dataset.with_epoch(num_worker_batches)  # each worker is iterating over this
     else:
         if args.distributed_evaluation:
-            num_batches = math.ceil(num_samples / (args.batch_size * args.world_size))
-        else:
-            num_batches = math.ceil(num_samples / args.batch_size)
+            num_samples = num_samples // args.world_size
+        num_batches = math.ceil(num_samples / args.batch_size)
 
     dataloader = wds.WebLoader(
         dataset,

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -79,6 +79,13 @@ def parse_args():
         help="Path to imagenet v2 for conducting zero shot evaluation.",
     )
     parser.add_argument(
+        "--distributed-evaluation",
+        action="store_true",
+        default=False,
+        help="Do evaluation in a distributed way.",
+    )
+
+    parser.add_argument(
         "--logs",
         type=str,
         default="./logs/",

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -57,12 +57,9 @@ def run(model, classifier, dataloader, args):
             top5 += acc5
             n += images.size(0)
     if args.distributed_evaluation:
-        n = torch.Tensor([n]).to(args.device)
-        torch.distributed.all_reduce(n)
-        n = n.item()
-        top = torch.Tensor([top1, top5]).to(args.device)
-        torch.distributed.all_reduce(top)
-        top1, top5 = top.tolist()
+        vals = torch.Tensor([n, top1, top5]).to(args.device)
+        torch.distributed.all_reduce(vals)
+        n, top1, top5 = vals.tolist()
     top1 = (top1 / n)
     top5 = (top5 / n)
     return top1, top5


### PR DESCRIPTION
Currently, evaluation is done on rank zero. This PR provides support for distributed evaluation (using an optional `--distributed-evaluation` argument) to make evaluation faster (supports both zero-shot and retrieval).