### PR TITLE
Honor the --skip-scheduler flag

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -68,7 +68,9 @@ def train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, tb_w
     end = time.time()
     for i, batch in enumerate(dataloader):
         step = num_batches_per_epoch * epoch + i
-        scheduler(step)
+        
+        if not args.skip_scheduler:
+            scheduler(step)
 
         images, texts = batch
         images = images.to(device=device, non_blocking=True)


### PR DESCRIPTION
`src/open_clip/params.py` currently contains a definition for a `--skip-scheduler` flag that is not used anywhere in the codebase. This is a one-line patch to fix this and make `--skip-scheduler` actually disable the learning rate scheduler in training.