### PR TITLE
Add roberta base ViT-B/32 pretrained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,9 +401,16 @@ A ViT-H/14 with a 78.0% top-1 ImageNet-1k zero-shot was trained on JUWELS Booste
 
 #### ViT-g/14 224x224
 
-A ViT-H/14 with a 76.6% top-1 ImageNet-1k zero-shot was trained on JUWELS Booster. See model details here https://huggingface.co/laion/CLIP-ViT-g-14-laion2B-s12B-b42K
+A ViT-g/14 with a 76.6% top-1 ImageNet-1k zero-shot was trained on JUWELS Booster. See model details here https://huggingface.co/laion/CLIP-ViT-g-14-laion2B-s12B-b42K
 
 This model was trained with a shorted schedule than other LAION-2B models with 12B samples seen instead of 32+B. It matches LAION-400M training in samples seen. Many zero-shot results are lower as a result, but despite this it performs very well in some OOD zero-shot and retrieval tasks.
+
+
+#### ViT-B/32 roberta base
+
+A ViT-B/32 with roberta base encoder with a 61.7% top-1 ImageNet-1k zero-shot was trained on stability. See model details here https://huggingface.co/laion/CLIP-ViT-B-32-roberta-base-laion2B-s12B-b32k
+This is the first openclip model using a HF text tower. It has better performance on a range of tasks compared to the standard text encoder, see [metrics](https://huggingface.co/laion/CLIP-ViT-B-32-roberta-base-laion2B-s12B-b32k/blob/main/unknown.png)
+
 
 #### YFCC-15M
 
@@ -459,7 +466,8 @@ Future trained models will use nn.GELU.
  ('ViT-L-14', 'laion2b_s32b_b82k'),
  ('ViT-L-14-336', 'openai'),
  ('ViT-H-14', 'laion2b_s32b_b79k'),
- ('ViT-g-14', 'laion2b_s12b_b42k')]
+ ('ViT-g-14', 'laion2b_s12b_b42k'),
+ ('roberta-ViT-B-32', 'laion2b_s12b_b32k'),]
 
 >>> model, train_transform, eval_transform = open_clip.create_model_and_transforms('ViT-B-32', pretrained='laion2b_s34b_b79k')
 ```

--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -142,6 +142,10 @@ _VITg14 = dict(
     laion2b_s12b_b42k=_pcfg(hf_hub='laion/CLIP-ViT-g-14-laion2B-s12B-b42K/'),
 )
 
+_robertaViTB32 = dict(
+    laion2b_s12b_b32k=_pcfg(hf_hub='laion/CLIP-ViT-B-32-roberta-base-laion2B-s12B-b32k/'),
+)
+
 _PRETRAINED = {
     "RN50": _RN50,
     "RN50-quickgelu": _RN50_quickgelu,
@@ -158,6 +162,7 @@ _PRETRAINED = {
     "ViT-L-14-336": _VITL14_336,
     "ViT-H-14": _VITH14,
     "ViT-g-14": _VITg14,
+    "roberta-ViT-B-32": _robertaViTB32,
 }
 
 

--- a/tests/test_inference_simple.py
+++ b/tests/test_inference_simple.py
@@ -7,10 +7,10 @@ import open_clip
 import os
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
-@pytest.mark.parametrize("jit", [False, True])
-def test_inference(jit):
-    model, _, preprocess = open_clip.create_model_and_transforms('ViT-B-32-quickgelu', pretrained='laion400m_e32', jit=jit)
-    tokenizer = get_tokenizer('ViT-B-32-quickgelu')
+@pytest.mark.parametrize("model_type,pretrained", [("ViT-B-32-quickgelu", "laion400m_e32"), ("roberta-ViT-B-32", "laion2b_s12b_b32k")])
+def test_inference_simple(model_type, pretrained):
+    model, _, preprocess = open_clip.create_model_and_transforms(model_type, pretrained=pretrained, jit=False)
+    tokenizer = get_tokenizer(model_type)
 
     current_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
A ViT-B/32 with roberta base encoder with a 61.7% top-1 ImageNet-1k zero-shot was trained on stability. See model details here https://huggingface.co/laion/CLIP-ViT-B-32-roberta-base-laion2B-s12B-b32k This is the first openclip model using a HF text tower. It has better performance on a range of tasks compared to the standard text encoder, see [metrics](https://huggingface.co/laion/CLIP-ViT-B-32-roberta-base-laion2B-s12B-b32k/blob/main/unknown.png)