### PR TITLE
add testing requirements for 'mt5-base-ViT-B-32'

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,5 @@ pytest-split==0.8.0
 pytest==7.2.0
 transformers
 timm==0.6.11
+sentencepiece
+protobuf==3.20.3


### PR DESCRIPTION
Fixes inference & train test for mt5-base-ViT-B-32.