### PR TITLE
fixing data filtering

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -154,7 +154,9 @@ def count_samples(dataloader):
 
 
 def filter_no_caption_or_no_image(sample):
-    return ('txt' in sample) and ('png' in sample or 'jpg' in sample)
+    has_caption = ('txt' in sample)
+    has_image = ('png' in sample or 'jpg' in sample or 'jpeg' in sample)
+    return has_caption and has_image 
 
 
 def log_and_continue(exn):
@@ -303,6 +305,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             num_samples = args.val_num_samples or 0  # eval will just exhaust the iterator if not specified
 
     shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
+    
     if resampled:
         pipeline = [ResampledShards2(input_shards, deterministic=True, epoch=shared_epoch)]
     else:
@@ -338,7 +341,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     pipeline.extend([
         wds.select(filter_no_caption_or_no_image),
         wds.decode("pilrgb", handler=log_and_continue),
-        wds.rename(image="jpg;png", text="txt"),
+        wds.rename(image="jpg;png;jpeg", text="txt"),
         wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
         wds.to_tuple("image", "text"),
         wds.batched(args.batch_size, partial=not is_train),

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -16,13 +16,13 @@ def parse_args(args):
         "--train-data",
         type=str,
         default=None,
-        help="Path to csv filewith training data",
+        help="Path to file(s) with training data",
     )
     parser.add_argument(
         "--val-data",
         type=str,
         default=None,
-        help="Path to csv file with validation data",
+        help="Path to file(s) with validation data",
     )
     parser.add_argument(
         "--train-num-samples",


### PR DESCRIPTION
The current code ignores samples where the image ends with `jpeg`, when there is no need to. In the extreme case where all the samples have the `jpeg` extension, the current code will silently hang forever with the `--dataset-resampled` flag, as it will keep trying to find valid samples but there will be none.