### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ ftfy
 tqdm
 huggingface_hub
 sentencepiece
+transformers
 protobuf==3.20.*


### PR DESCRIPTION
transformers seems to be required to use open_clip, not just for training. see https://github.com/mlfoundations/open_clip/blob/60534f4774b11a2532536f3f264a666f11fbb6b6/src/open_clip/hf_model.py#L102