### PR TITLE
Regression test against v2.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ on:
         type: string
 
 env:
-  REVISION_REFERENCE: 9d31b2ec4df6d8228f370ff20c8267ec6ba39383 # v2.7.0 + pretrained_hf param
+  REVISION_REFERENCE: v2.8.2
+  #9d31b2ec4df6d8228f370ff20c8267ec6ba39383 earliest compatible v2.7.0 + pretrained_hf param
 
 jobs:
   Tests:


### PR DESCRIPTION
Changes CI to run regression tests against latest release (v2.8.2 at time of writing)