### PR TITLE
Ignore pad tokens in captioning loss

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -126,7 +126,7 @@ class CoCaLoss(ClipLoss):
         self,
         caption_loss_weight,
         clip_loss_weight,
-        pad_id=-100,
+        pad_id=0, # pad_token for open_clip custom tokenizer
         local_loss=False,
         gather_with_grad=False,
         cache_labels=False,
@@ -145,7 +145,7 @@ class CoCaLoss(ClipLoss):
 
         self.clip_loss_weight = clip_loss_weight
         self.caption_loss_weight = caption_loss_weight
-        self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id)
+        self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id, ignore_index=pad_id)
 
     def forward(self, image_features, text_features, logits, labels, logit_scale):
         clip_loss = super().forward(image_features, text_features, logit_scale)

--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -145,7 +145,7 @@ class CoCaLoss(ClipLoss):
 
         self.clip_loss_weight = clip_loss_weight
         self.caption_loss_weight = caption_loss_weight
-        self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id, ignore_index=pad_id)
+        self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id)
 
     def forward(self, image_features, text_features, logits, labels, logit_scale):
         clip_loss = super().forward(image_features, text_features, logit_scale)


### PR DESCRIPTION
Currently captioning loss is ignoring the wrong pad tokens, open_clip tokenizer uses 0 and not -100.