### PR TITLE
Utility for sycning with s3 and loading checkpoints from s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,21 @@ There are also `m` loss computations instead of the usual 1.
 
 For more information see Cui et al. (https://arxiv.org/abs/2112.09331) or Pham et al. (https://arxiv.org/abs/2111.10050). 
 
+### Support for remote loading/training
+
+It is always possible to resume directly from a remote file, e.g., a file in an s3 bucket. Just set `--resume s3://<path-to-checkpoint> `.
+This will work with any filesystem supported by `fsspec`.
+
+It is also possible to train `open_clip` models while continuously backing up to s3. This can help to avoid slow local file systems.
+
+Say that your node has a local ssd `/scratch`, an s3 bucket `s3://<path-to-bucket>`.
+
+In that case, set `--logs /scratch` and `--remote-sync s3://<path-to-bucket>`. Then, a background process will sync `/scratch/<run-name>` to `s3://<path-to-bucket>/<run-name>`. After syncing, the background process will sleep for `--remote-sync-frequency` seconds, which defaults to 5 minutes.
+
+There is also experimental support for syncing to other remote file systems, not just s3. To do so, specify `--remote-sync-protocol fsspec`. However, this is currently very slow.
+
+Also, to optionally avoid saving too many checkpoints locally when using these features, you can use `--delete-previous-checkpoint` which deletes the previous checkpoint after saving a new one.
+
 ## Scaling trends
 
 The plot below shows how zero-shot performance of CLIP models varies as we scale the number of samples used for training. Zero-shot performance increases steadily for both ImageNet and [ImageNetV2](https://arxiv.org/abs/1902.10811), and is far from saturated at ~15M samples.

--- a/README.md
+++ b/README.md
@@ -512,9 +512,11 @@ Say that your node has a local ssd `/scratch`, an s3 bucket `s3://<path-to-bucke
 
 In that case, set `--logs /scratch` and `--remote-sync s3://<path-to-bucket>`. Then, a background process will sync `/scratch/<run-name>` to `s3://<path-to-bucket>/<run-name>`. After syncing, the background process will sleep for `--remote-sync-frequency` seconds, which defaults to 5 minutes.
 
-There is also experimental support for syncing to other remote file systems, not just s3. To do so, specify `--remote-sync-protocol fsspec`. However, this is currently very slow.
+There is also experimental support for syncing to other remote file systems, not just s3. To do so, specify `--remote-sync-protocol fsspec`. However, this is currently very slow and not recommended.
 
 Also, to optionally avoid saving too many checkpoints locally when using these features, you can use `--delete-previous-checkpoint` which deletes the previous checkpoint after saving a new one.
+
+Note: if you are using this feature with `--resume latest`, there are a few warnings. First, use with `--save-most-recent` is not supported. Second, only `s3` is supported. Finally, since the sync happens in the background, it is possible that the most recent checkpoint may not be finished syncing to the remote.
 
 ## Scaling trends
 

--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -8,3 +8,4 @@ pandas
 braceexpand
 huggingface_hub
 transformers
+fsspec

--- a/src/training/file_utils.py
+++ b/src/training/file_utils.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import multiprocessing
+import subprocess
+import time
+import fsspec
+import torch
+
+def sync_s3(local_dir, s3_dir):
+    result = subprocess.run(["aws", "s3", "sync", local_dir, s3_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        logging.info(f"Error: Failed to sync with S3 bucket")
+        return False
+        
+    logging.info(f"Successfully synced with S3 bucket")
+    return True
+
+def keep_running_sync_s3(sync_every, local_dir, s3_dir):
+    while True:
+        time.sleep(sync_every)
+        sync_s3(local_dir, s3_dir)
+
+def start_sync_process(sync_every, local_dir, s3_dir):
+    p = multiprocessing.Process(target=keep_running_sync_s3, args=(sync_every, local_dir, s3_dir))
+    return p
+
+# Note: we are not currently using this save function.
+def pt_save(pt_obj, file_path):
+    of = fsspec.open(file_path, "wb")
+    with of as f:
+        torch.save(pt_obj, file_path)
+
+def pt_load(file_path, map_location=None):
+    if file_path.startswith('s3'):
+        logging.info('Loading checkpoint from S3, which may take a bit.')
+    of = fsspec.open(file_path, "rb")
+    with of as f:
+        out = torch.load(f)
+    return out
+
+def check_exists(file_path):
+    if file_path.startswith('s3'):
+        result = subprocess.run(["aws", "s3", "ls", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return result.returncode == 0
+    else:
+        return os.path.isfile(file_path)

--- a/src/training/file_utils.py
+++ b/src/training/file_utils.py
@@ -5,23 +5,59 @@ import subprocess
 import time
 import fsspec
 import torch
+from tqdm import tqdm
 
-def sync_s3(local_dir, s3_dir):
-    result = subprocess.run(["aws", "s3", "sync", local_dir, s3_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def remote_sync_s3(local_dir, remote_dir):
+    # skip epoch_latest which can change during sync.
+    result = subprocess.run(["aws", "s3", "sync", local_dir, remote_dir, '--exclude', '*epoch_latest.pt'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
-        logging.info(f"Error: Failed to sync with S3 bucket")
+        logging.error(f"Error: Failed to sync with S3 bucket {result.stderr.decode('utf-8')}")
         return False
         
     logging.info(f"Successfully synced with S3 bucket")
     return True
 
-def keep_running_sync_s3(sync_every, local_dir, s3_dir):
+def remote_sync_fsspec(local_dir, remote_dir):
+    # FIXME currently this is slow and not recommended. Look into speeding up.
+    a = fsspec.get_mapper(local_dir)
+    b = fsspec.get_mapper(remote_dir)
+
+    for k in a:
+        # skip epoch_latest which can change during sync.
+        if 'epoch_latest.pt' in k:
+            continue
+
+        logging.info(f'Attempting to sync {k}')
+        if k in b and len(a[k]) == len(b[k]):
+            logging.debug(f'Skipping remote sync for {k}.')
+            continue
+
+        try:
+            logging.info(f'Successful sync for {k}.')
+            b[k] = a[k]
+        except Exception as e:
+            logging.info(f'Error during remote sync for {k}: {e}')
+            return False
+
+    return True
+
+def remote_sync(local_dir, remote_dir, protocol):
+    logging.info('Starting remote sync.')
+    if protocol == 's3':
+        return remote_sync_s3(local_dir, remote_dir)
+    elif protocol == 'fsspec':
+        return remote_sync_fsspec(local_dir, remote_dir)
+    else:
+        logging.error('Remote protocol not known')
+        return False
+
+def keep_running_remote_sync(sync_every, local_dir, remote_dir, protocol):
     while True:
         time.sleep(sync_every)
-        sync_s3(local_dir, s3_dir)
+        remote_sync(local_dir, remote_dir, protocol)
 
-def start_sync_process(sync_every, local_dir, s3_dir):
-    p = multiprocessing.Process(target=keep_running_sync_s3, args=(sync_every, local_dir, s3_dir))
+def start_sync_process(sync_every, local_dir, remote_dir, protocol):
+    p = multiprocessing.Process(target=keep_running_remote_sync, args=(sync_every, local_dir, remote_dir, protocol))
     return p
 
 # Note: we are not currently using this save function.
@@ -31,16 +67,17 @@ def pt_save(pt_obj, file_path):
         torch.save(pt_obj, file_path)
 
 def pt_load(file_path, map_location=None):
-    if file_path.startswith('s3'):
-        logging.info('Loading checkpoint from S3, which may take a bit.')
+    if not file_path.startswith('/'):
+        logging.info('Loading remote checkpoint, which may take a bit.')
     of = fsspec.open(file_path, "rb")
     with of as f:
         out = torch.load(f)
     return out
 
 def check_exists(file_path):
-    if file_path.startswith('s3'):
-        result = subprocess.run(["aws", "s3", "ls", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        return result.returncode == 0
-    else:
-        return os.path.isfile(file_path)
+    try:
+        with fsspec.open(file_path):
+            pass
+    except FileNotFoundError:
+        return False
+    return True

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import re
+import subprocess
 import sys
 import random
 from datetime import datetime
@@ -50,9 +51,16 @@ def natural_key(string_):
     return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', string_.lower())]
 
 
-def get_latest_checkpoint(path: str):
+def get_latest_checkpoint(path: str, remote : bool):
     # as writen, this glob recurses, so can pick up checkpoints across multiple sub-folders
-    checkpoints = glob.glob(path + '**/*.pt', recursive=True)
+    if remote:
+        result = subprocess.run(["aws", "s3", "ls", path + "/"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(result)
+        if result.returncode == 1:
+            return None
+        checkpoints = [os.path.join(path, x.split(' ')[-1]) for x in result.stdout.decode().split('\n')[:-1]]
+    else:
+        checkpoints = glob.glob(path + '**/*.pt', recursive=True)
     if checkpoints:
         checkpoints = sorted(checkpoints, key=natural_key)
         return checkpoints[-1]
@@ -122,23 +130,33 @@ def main(args):
 
     if resume_latest:
         resume_from = None
+        checkpoint_path = args.checkpoint_path
+        # If using remote_sync, need to check the remote instead of the local checkpoints folder.
+        if args.remote_sync is not None:
+            checkpoint_path = os.path.join(args.remote_sync, args.name, "checkpoints")
+            if args.save_most_recent:
+                print('Error. Cannot use save-most-recent with remote_sync and resume latest.')
+                return -1
+            if args.remote_sync_protocol != 's3':
+                print('Error. Sync protocol not supported when using resume latest.')
+                return -1
         if is_master(args):
             # Checking for existing checkpoint via master rank only. It is possible for
             # different rank processes to see different files if a shared file-system is under
             # stress, however it's very difficult to fully work around such situations.
             if args.save_most_recent:
                 # if --save-most-recent flag is set, look for latest at a fixed filename
-                resume_from = os.path.join(args.checkpoint_path, LATEST_CHECKPOINT_NAME)
+                resume_from = os.path.join(checkpoint_path, LATEST_CHECKPOINT_NAME)
                 if not os.path.exists(resume_from):
                     # If no latest checkpoint has been saved yet, don't try to resume
                     resume_from = None
             else:
                 # otherwise, list checkpoint dir contents and pick the newest checkpoint
-                resume_from = get_latest_checkpoint(args.checkpoint_path)
+                resume_from = get_latest_checkpoint(checkpoint_path, remote=args.remote_sync is not None)
             if resume_from:
                 logging.info(f'Found latest resume checkpoint at {resume_from}.')
             else:
-                logging.info(f'No latest resume checkpoint found in {args.checkpoint_path}.')
+                logging.info(f'No latest resume checkpoint found in {checkpoint_path}.')
         if args.distributed:
             # sync found checkpoint path to all ranks
             resume_from = broadcast_object(args, resume_from)

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -332,7 +332,18 @@ def parse_args(args):
         default=100,
         help="Log every n steps to tensorboard/console/wandb.",
     )
-
+    parser.add_argument(
+        "--sync-s3",
+        type=str,
+        default=None,
+        help="If you provide a path, it will sync it s3.",
+    )
+    parser.add_argument(
+        "--sync-s3-frequency",
+        type=int,
+        default=120,
+        help="How frequently to sync to s3.",
+    )
 
     args = parser.parse_args(args)
 

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -333,18 +333,29 @@ def parse_args(args):
         help="Log every n steps to tensorboard/console/wandb.",
     )
     parser.add_argument(
-        "--sync-s3",
+        "--remote-sync",
         type=str,
         default=None,
-        help="If you provide a path, it will sync it s3.",
+        help="Optinoally sync with a remote path specified by this arg",
     )
     parser.add_argument(
-        "--sync-s3-frequency",
+        "--remote-sync-frequency",
         type=int,
-        default=120,
-        help="How frequently to sync to s3.",
+        default=300,
+        help="How frequently to sync to a remote directly if --remote-sync is not None.",
     )
-
+    parser.add_argument(
+        "--remote-sync-protocol",
+        choices=["s3", "fsspec"],
+        default="s3",
+        help="How to do the remote sync backup if --remote-sync is not None.",
+    )
+    parser.add_argument(
+        "--delete-previous-checkpoint",
+        default=False,
+        action="store_true",
+        help="If true, delete previous checkpoint after storing a new one."
+    )
     args = parser.parse_args(args)
 
     # If some params are not passed, we use the default values based on model name.


### PR DESCRIPTION
This PR introduces two additional arguments, which are `--sync-s3` and `--sync-s3-frequency`. Recommended use is to do `--sync-s3 s3://<path-to-bucket>` and `--logs /scratch/logs` which is hopefully local ssd.

Then, as you run, you should see logs at `/scratch/logs/<name>` and `s3://<path-to-bucket>/<name>`. So you don't have to use the local file system.

This PR also supports loading from `s3://<path-to-checkpoint>` -- it's a bit slow but not too bad.