### PR TITLE
Correct num_samples logging

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -162,7 +162,7 @@ def train_one_epoch(model, data, epoch, optimizer, scaler, scheduler, args, tb_w
         batch_count = i_accum + 1
         if is_master(args) and (i_accum % args.log_every_n_steps or batch_count == num_batches_per_epoch):
             batch_size = len(images)
-            num_samples = batch_count * batch_size * args.world_size
+            num_samples = batch_count * batch_size * args.accum_freq * args.world_size
             samples_per_epoch = dataloader.num_samples
             percent_complete = 100.0 * batch_count / num_batches_per_epoch
 


### PR DESCRIPTION
Multiply the batch size by the `accum-freq` argument to get the effective batch size and so compute the real number of samples.