### PR TITLE
Allow webp in webdataset

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -152,8 +152,8 @@ def count_samples(dataloader):
 
 def filter_no_caption_or_no_image(sample):
     has_caption = ('txt' in sample)
-    has_image = ('png' in sample or 'jpg' in sample or 'jpeg' in sample)
-    return has_caption and has_image 
+    has_image = ('png' in sample or 'jpg' in sample or 'jpeg' in sample or 'webp' in sample)
+    return has_caption and has_image
 
 
 def log_and_continue(exn):
@@ -349,7 +349,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     pipeline.extend([
         wds.select(filter_no_caption_or_no_image),
         wds.decode("pilrgb", handler=log_and_continue),
-        wds.rename(image="jpg;png;jpeg", text="txt"),
+        wds.rename(image="jpg;png;jpeg;webp", text="txt"),
         wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
         wds.to_tuple("image", "text"),
         wds.batched(args.batch_size, partial=not is_train),


### PR DESCRIPTION
These small changes allow training on a webdataset that contains webp images.

For example, the [img2dataset tool](https://github.com/rom1504/img2dataset) has webp as an image encoding option. 