### PR TITLE
Fix braceexpand memory explosion for complex urls

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -9,7 +9,6 @@ import time
 from dataclasses import dataclass
 from multiprocessing import Value
 
-import braceexpand
 import numpy as np
 import pandas as pd
 import torch
@@ -73,8 +72,8 @@ class DataInfo:
 
 
 def get_dataset_size(shards):
-    shards_list = list(braceexpand.braceexpand(shards))
-    dir_path = os.path.dirname(shards)
+    shards_list = wds.shardlists.expand_urls(shards)
+    dir_path = os.path.dirname(shards_list[0])
     sizes_filename = os.path.join(dir_path, 'sizes.json')
     len_filename = os.path.join(dir_path, '__len__')
     if os.path.exists(sizes_filename):

--- a/tests/test_num_shards.py
+++ b/tests/test_num_shards.py
@@ -1,0 +1,20 @@
+import pytest
+
+from training.data import get_dataset_size
+
+@pytest.mark.parametrize(
+    "shards,expected_size",
+    [
+        ('/path/to/shard.tar', 1),
+        ('/path/to/shard_{000..000}.tar', 1),
+        ('/path/to/shard_{000..009}.tar', 10),
+        ('/path/to/shard_{000..009}_{000..009}.tar', 100),
+        ('/path/to/shard.tar::/path/to/other_shard_{000..009}.tar', 11),
+        ('/path/to/shard_{000..009}.tar::/path/to/other_shard_{000..009}.tar', 20),
+        (['/path/to/shard.tar'], 1),
+        (['/path/to/shard.tar', '/path/to/other_shard.tar'], 2),
+    ]
+)
+def test_num_shards(shards, expected_size):
+    _, size = get_dataset_size(shards)
+    assert size == expected_size, f'Expected {expected_size} for {shards} but found {size} instead.'


### PR DESCRIPTION
Currently handling complex webdataset url patterns in `args.train_data` can lead to a unnecessary memory explosion, when using `::` to concatenate multiple data sources. This can be correctly parsed by webdataset, using `wds.shardlists.expand_urls(urls))`.

See Issue https://github.com/mlfoundations/open_clip/issues/278.