### PR TITLE
Add possibility for bounding box blurring in train transform.

### DIFF
--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -203,6 +203,7 @@ def create_model_and_transforms(
         image_mean: Optional[Tuple[float, ...]] = None,
         image_std: Optional[Tuple[float, ...]] = None,
         cache_dir: Optional[str] = None,
+        blur_field: Optional[str] = None,
 ):
     model = create_model(
         model_name,
@@ -224,13 +225,15 @@ def create_model_and_transforms(
         model.visual.image_size,
         is_train=True,
         mean=image_mean,
-        std=image_std
+        std=image_std,
+        blur_field=blur_field
     )
     preprocess_val = image_transform(
         model.visual.image_size,
         is_train=False,
         mean=image_mean,
-        std=image_std
+        std=image_std,
+        blur_field=blur_field
     )
 
     return model, preprocess_train, preprocess_val
@@ -248,6 +251,7 @@ def create_model_from_pretrained(
         image_mean: Optional[Tuple[float, ...]] = None,
         image_std: Optional[Tuple[float, ...]] = None,
         cache_dir: Optional[str] = None,
+        blur_field: Optional[str] = None,
 ):
     if not is_pretrained_cfg(model_name, pretrained) and not os.path.exists(pretrained):
         raise RuntimeError(
@@ -274,7 +278,8 @@ def create_model_from_pretrained(
         model.visual.image_size,
         is_train=False,
         mean=image_mean,
-        std=image_std
+        std=image_std,
+        blur_field=blur_field
     )
 
     return model, preprocess

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -25,6 +25,7 @@ class BoundingBoxBlurrer(nn.Module):
         self.blur_field = blur_field
 
     def forward(self, item):
+        # If no blur field is specified, then skip this transform.
         if self.blur_field is None:
             return item
 

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -144,26 +144,25 @@ def image_transform(
         image_size = image_size[0]
 
     normalize = Normalize(mean=mean, std=std)
+    transforms = [BoundingBoxBlurrer(blur_field=blur_field)] if blur_field is not None else []
     if is_train:
-        return Compose([
-            BoundingBoxBlurrer(blur_field=blur_field),
+        transforms.extend([
             RandomResizedCrop(image_size, scale=(0.9, 1.0), interpolation=InterpolationMode.BICUBIC),
             _convert_to_rgb,
             ToTensor(),
             normalize,
         ])
+        return Compose(transforms)
     else:
         if resize_longest_max:
-            transforms = [
-                BoundingBoxBlurrer(blur_field=blur_field),
-                ResizeMaxSize(image_size, fill=fill_color)
-            ]
+            transforms.extend([
+                ResizeMaxSize(image_size, fill=fill_color),
+            ])
         else:
-            transforms = [
-                BoundingBoxBlurrer(blur_field=blur_field),
+            transforms.extend([
                 Resize(image_size, interpolation=InterpolationMode.BICUBIC),
                 CenterCrop(image_size),
-            ]
+            ])
         transforms.extend([
             _convert_to_rgb,
             ToTensor(),

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -1,5 +1,7 @@
 from typing import Optional, Sequence, Tuple
 
+import numpy as np
+
 import torch
 import torch.nn as nn
 import torchvision.transforms.functional as F
@@ -7,7 +9,76 @@ import torchvision.transforms.functional as F
 from torchvision.transforms import Normalize, Compose, RandomResizedCrop, InterpolationMode, ToTensor, Resize, \
     CenterCrop
 
+from PIL import Image
+
 from .constants import OPENAI_DATASET_MEAN, OPENAI_DATASET_STD
+
+
+class BoundingBoxBlurrer(nn.Module):
+    
+    def __init__(self, blur_field) -> None:
+        self.blur_field = blur_field
+
+    def forward(self, item):
+        if self.blur_field is None:
+            return item
+
+        img, data = item
+        bbox_list = data.get(self.blur_field, [])
+
+        # Skip if there are no boxes to blur.
+        if len(bbox_list) == 0:
+            return img
+
+        if isinstance(img, torch.Tensor):
+            height, width = img.shape[:2]
+        else:
+            width, height = img.size
+
+        mask = torch.zeros((height, width), dtype=torch.float32)
+
+        # Incorporate max diagonal from ImageNet code.
+        max_diagonal = 0
+
+        for bbox in bbox_list:
+            adjusted_bbox = [
+                int(bbox[0] * width),
+                int(bbox[1] * height),
+                int(bbox[2] * width),
+                int(bbox[3] * height),
+            ]
+
+            diagonal = max(adjusted_bbox[2] - adjusted_bbox[0], adjusted_bbox[3] - adjusted_bbox[1])
+            max_diagonal = max(max_diagonal, diagonal)
+
+            # Adjusting bbox as in:
+            # https://github.com/princetonvisualai/imagenet-face-obfuscation
+            adjusted_bbox[0] = int(adjusted_bbox[0] - 0.1 * diagonal)
+            adjusted_bbox[1] = int(adjusted_bbox[1] - 0.1 * diagonal)
+            adjusted_bbox[2] = int(adjusted_bbox[2] + 0.1 * diagonal)
+            adjusted_bbox[3] = int(adjusted_bbox[3] + 0.1 * diagonal)
+
+            # Clipping for indexing.
+            adjusted_bbox[0] = np.clip(adjusted_bbox[0], 0, width - 1)
+            adjusted_bbox[1] = np.clip(adjusted_bbox[1], 0, height - 1)
+            adjusted_bbox[2] = np.clip(adjusted_bbox[2], 0, width - 1)
+            adjusted_bbox[3] = np.clip(adjusted_bbox[3], 0, height - 1)
+
+            mask[adjusted_bbox[1] : adjusted_bbox[3], adjusted_bbox[0] : adjusted_bbox[2], ...] = 1.0
+
+        sigma = 0.1 * max_diagonal
+        ksize = int(2 * np.ceil(4 * sigma)) + 1
+        blurred_img = F.gaussian_blur(img, kernel_size=ksize, sigma=sigma)
+        blurred_mask = F.gaussian_blur(mask, kernel_size=ksize, sigma=sigma)
+
+        if isinstance(img, torch.Tensor):
+            result = img.float() * (1 - blurred_mask) + blurred_img.float() * blurred_mask
+            if img.dtype == torch.uint8:
+                result = result.type(torch.uint8)
+        else:
+            blurred_mask = F.to_pil_image(blurred_mask)
+            result = Image.composite(blurred_img, img, blurred_mask)
+        return result
 
 
 class ResizeMaxSize(nn.Module):
@@ -47,6 +118,7 @@ def image_transform(
         std: Optional[Tuple[float, ...]] = None,
         resize_longest_max: bool = False,
         fill_color: int = 0,
+        blur_field: Optional[str] = None,
 ):
     mean = mean or OPENAI_DATASET_MEAN
     if not isinstance(mean, (list, tuple)):
@@ -63,6 +135,7 @@ def image_transform(
     normalize = Normalize(mean=mean, std=std)
     if is_train:
         return Compose([
+            BoundingBoxBlurrer(blur_field=blur_field),
             RandomResizedCrop(image_size, scale=(0.9, 1.0), interpolation=InterpolationMode.BICUBIC),
             _convert_to_rgb,
             ToTensor(),
@@ -71,10 +144,12 @@ def image_transform(
     else:
         if resize_longest_max:
             transforms = [
+                BoundingBoxBlurrer(blur_field=blur_field),
                 ResizeMaxSize(image_size, fill=fill_color)
             ]
         else:
             transforms = [
+                BoundingBoxBlurrer(blur_field=blur_field),
                 Resize(image_size, interpolation=InterpolationMode.BICUBIC),
                 CenterCrop(image_size),
             ]

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -175,6 +175,7 @@ def main(args):
         pretrained_image=args.pretrained_image,
         image_mean=args.image_mean,
         image_std=args.image_std,
+        blur_field=args.blur_field,
     )
     random_seed(args.seed, args.rank)
 

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -333,7 +333,7 @@ def parse_args(args):
         help="Log every n steps to tensorboard/console/wandb.",
     )
     parser.add_argument(
-        "--blur_field",
+        "--blur-field",
         type=str,
         default=None,
         help="Bounding box to blur field in webdataset json."

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -332,6 +332,12 @@ def parse_args(args):
         default=100,
         help="Log every n steps to tensorboard/console/wandb.",
     )
+    parser.add_argument(
+        "--blur_field",
+        type=str,
+        default=None,
+        help="Bounding box to blur field in webdataset json."
+    )
 
 
     args = parser.parse_args(args)


### PR DESCRIPTION
This PR incorporates bounding box blurring in the dataloader pipeline, in the case of webdataset input.

Given some input image and a field with bounding box metadata in the json file of each sample in the webdataset, this allows for on-the-fly blurring of parts of images during training.

Blurring is derived from https://github.com/princetonvisualai/imagenet-face-obfuscation.
