### PR TITLE
set wandb id to args.name

### DIFF
--- a/src/training/main.py
+++ b/src/training/main.py
@@ -292,6 +292,7 @@ def main(args):
         wandb.init(
             project=args.wandb_project_name,
             name=args.name,
+            id=args.name,
             notes=args.wandb_notes,
             tags=[],
             resume='auto',


### PR DESCRIPTION
Set `id` to `args.name` when initializing wandb so multiple parallel runs are not collapsed into a single one. See https://github.com/mlfoundations/open_clip/issues/340.