### PR TITLE
Adding const-lr and const-lr-cooldown LR schedulers

### DIFF
--- a/src/training/main.py
+++ b/src/training/main.py
@@ -282,8 +282,7 @@ def main(args):
             cooldown_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.lr_cooldown_epochs
             scheduler = const_lr_cooldown(optimizer, args.lr, args.warmup, cooldown_steps, args.lr_cooldown_power, args.lr_cooldown_end, total_steps)
         else:
-            logging.error(f'Error - unknown scheduler, {args.lr_scheduler}. Please use a lr scheduler of known type.')
-            logging.error('(Current available options are: cosine, const, const-cooldown.)')
+            logging.error(f'Unknown scheduler, {args.lr_scheduler}. Current available options are: cosine, const, const-cooldown.')
             exit(1)
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -31,9 +31,7 @@ from training.data import get_data
 from training.distributed import is_master, init_distributed_device, broadcast_object
 from training.logger import setup_logging
 from training.params import parse_args
-from training.scheduler import cosine_lr
-from training.scheduler import const_lr
-from training.scheduler import const_lr_cooldown
+from training.scheduler import cosine_lr, const_lr, const_lr_cooldown
 from training.train import train_one_epoch, evaluate
 
 
@@ -284,9 +282,8 @@ def main(args):
             cooldown_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.lr_cooldown_epochs
             scheduler = const_lr_cooldown(optimizer, args.lr, args.warmup, cooldown_steps, args.lr_cooldown_power, args.lr_cooldown_end, total_steps)
         else:
-            logging.info(f'Unknown scheduler, {args.lr_scheduler}.')
-            logging.info('Error. Please use a lr scheduler of known type.')
-            logging.info('(Current available options are: cosine, const, const-cooldown.)')
+            logging.error(f'Error - unknown scheduler, {args.lr_scheduler}. Please use a lr scheduler of known type.')
+            logging.error('(Current available options are: cosine, const, const-cooldown.)')
             exit(1)
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -280,11 +280,14 @@ def main(args):
         elif args.lr_scheduler == "const":
             scheduler = const_lr(optimizer, args.lr, args.warmup, total_steps)
         elif args.lr_scheduler == "const-cooldown":
-            assert args.cooldown_epochs is not None, "Please specify the number of cooldown epochs for this lr schedule."
-            cooldown_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.cooldown_epochs
-            scheduler = const_lr_cooldown(optimizer, args.lr, args.warmup, cooldown_steps, args.power_lr, args.end_lr, total_steps)
+            assert args.lr_cooldown_epochs is not None, "Please specify the number of cooldown epochs for this lr schedule."
+            cooldown_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.lr_cooldown_epochs
+            scheduler = const_lr_cooldown(optimizer, args.lr, args.warmup, cooldown_steps, args.lr_cooldown_power, args.lr_cooldown_end, total_steps)
         else:
-            print(f"Unknown scheduler, {args.lr_scheduler}")
+            logging.info(f'Unknown scheduler, {args.lr_scheduler}.')
+            logging.info('Error. Please use a lr scheduler of known type.')
+            logging.info('(Current available options are: cosine, const, const-cooldown.)')
+            exit(1)
 
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
     args.save_logs = args.logs and args.logs.lower() != 'none' and is_master(args)

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -275,11 +275,11 @@ def main(args):
     scheduler = None
     if 'train' in data and optimizer is not None:
         total_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.epochs
-        if args.lr_scheduler == "cosine-annealing":
+        if args.lr_scheduler == "cosine":
             scheduler = cosine_lr(optimizer, args.lr, args.warmup, total_steps)
-        elif args.lr_scheduler == "const-lr":
+        elif args.lr_scheduler == "const":
             scheduler = const_lr(optimizer, args.lr, args.warmup, total_steps)
-        elif args.lr_scheduler == "const-lr-cooldown":
+        elif args.lr_scheduler == "const-cooldown":
             assert args.cooldown_epochs is not None, "Please specify the number of cooldown epochs for this lr schedule."
             cooldown_steps = (data["train"].dataloader.num_batches // args.accum_freq) * args.cooldown_epochs
             scheduler = const_lr_cooldown(optimizer, args.lr, args.warmup, cooldown_steps, args.power_lr, args.end_lr, total_steps)

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -125,6 +125,15 @@ def parse_args(args):
         help="Use this flag to skip the learning rate decay.",
     )
     parser.add_argument(
+        "--lr-scheduler",
+        type=str,
+        default='cosine-annealing',
+        help="LR scheduler. Options: cosine-annealing (cosine schedule, default), const-lr (constant lr), const-lr-cooldown (constant lr followed by a cooldown)",
+    )
+    parser.add_argument("--end-lr", type=float, default=0.0, help="End learning rate for cooldown schedule. Default: 0")
+    parser.add_argument("--power-lr", type=float, default=1.0, help="Power for polynomial cooldown schedule. Default: 1.0 (implementing simple linear decay)")
+    parser.add_argument("--cooldown-epochs", type=int, default=None, help="Epochs to perform cooldown for cooldown schedule. Will start performing cooldown from total_epochs - cooldown_epochs on.")    
+    parser.add_argument(
         "--save-frequency", type=int, default=1, help="How often to save checkpoints."
     )
     parser.add_argument(

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -127,12 +127,12 @@ def parse_args(args):
     parser.add_argument(
         "--lr-scheduler",
         type=str,
-        default='cosine-annealing',
-        help="LR scheduler. Options: cosine-annealing (cosine schedule, default), const-lr (constant lr), const-lr-cooldown (constant lr followed by a cooldown)",
+        default='cosine',
+        help="LR scheduler. Options: cosine (cosine schedule, default), const (constant lr), const-cooldown (constant lr followed by a cooldown)",
     )
     parser.add_argument("--end-lr", type=float, default=0.0, help="End learning rate for cooldown schedule. Default: 0")
     parser.add_argument("--power-lr", type=float, default=1.0, help="Power for polynomial cooldown schedule. Default: 1.0 (implementing simple linear decay)")
-    parser.add_argument("--cooldown-epochs", type=int, default=None, help="Epochs to perform cooldown for cooldown schedule. Will start performing cooldown from total_epochs - cooldown_epochs on.")    
+    parser.add_argument("--cooldown-epochs", type=int, default=None, help="Epochs to perform cooldown for cooldown schedule. Will start performing cooldown from total_epochs - cooldown_epochs on.")
     parser.add_argument(
         "--save-frequency", type=int, default=1, help="How often to save checkpoints."
     )

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -130,9 +130,9 @@ def parse_args(args):
         default='cosine',
         help="LR scheduler. Options: cosine (cosine schedule, default), const (constant lr), const-cooldown (constant lr followed by a cooldown)",
     )
-    parser.add_argument("--end-lr", type=float, default=0.0, help="End learning rate for cooldown schedule. Default: 0")
-    parser.add_argument("--power-lr", type=float, default=1.0, help="Power for polynomial cooldown schedule. Default: 1.0 (implementing simple linear decay)")
-    parser.add_argument("--cooldown-epochs", type=int, default=None, help="Epochs to perform cooldown for cooldown schedule. Will start performing cooldown from total_epochs - cooldown_epochs on.")
+    parser.add_argument("--lr-cooldown-end", type=float, default=0.0, help="End learning rate for cooldown schedule. Default: 0")
+    parser.add_argument("--lr-cooldown-power", type=float, default=1.0, help="Power for polynomial cooldown schedule. Default: 1.0 (implementing simple linear decay)")
+    parser.add_argument("--lr-cooldown-epochs", type=int, default=None, help="Epochs to perform cooldown for cooldown schedule. Will start performing cooldown from total_epochs - cooldown_epochs on.")
     parser.add_argument(
         "--save-frequency", type=int, default=1, help="How often to save checkpoints."
     )

--- a/src/training/scheduler.py
+++ b/src/training/scheduler.py
@@ -10,6 +10,36 @@ def _warmup_lr(base_lr, warmup_length, step):
     return base_lr * (step + 1) / warmup_length
 
 
+def const_lr(optimizer, base_lr, warmup_length, steps):
+    def _lr_adjuster(step):
+        if step < warmup_length:
+            lr = _warmup_lr(base_lr, warmup_length, step)
+        else:
+            lr = base_lr
+        assign_learning_rate(optimizer, lr)
+        return lr
+    return _lr_adjuster
+
+
+def const_lr_cooldown(optimizer, base_lr, warmup_length, cooldown_steps, power, end_lr, steps):
+    def _lr_adjuster(step):
+        start_cooldown_step = steps - cooldown_steps
+        if step < warmup_length:
+            lr = _warmup_lr(base_lr, warmup_length, step)
+        else:
+            if step < start_cooldown_step:
+                lr = base_lr
+            else:
+                e = step - start_cooldown_step
+                es = steps - start_cooldown_step
+                # linear decay if power == 1; polynomial decay otherwise;
+                decay = (1 - (e/es)) ** power
+                lr = decay * (base_lr - end_lr) + end_lr
+        assign_learning_rate(optimizer, lr)
+        return lr
+    return _lr_adjuster
+
+
 def cosine_lr(optimizer, base_lr, warmup_length, steps):
     def _lr_adjuster(step):
         if step < warmup_length:


### PR DESCRIPTION
Adding const-lr and const-lr-cooldown LR schedulers for training with const lr followed by a cooldown schedule. 

Motivation is to have a training duration independent schedule. With this, having only a single full training run for max samples seen can be for instance used for performance evaluation at any samples seen smaller than the max, without repeating the experiment (contrary to training duration dependent schedules, eg cosine annealing). 

Also, training can be continued to arbitrary sample seen scale from any checkpoint when using training duration independent schedules.

Additional options are:

--lr-scheduler "cosine": cosine annealing (current default)

--lr-scheduler "const" : using const learning rate (together with warm up schedule if defined)

--lr-scheduler "const-cooldown" : using const learning rate followed by a cooldown schedule (linear and polynomial schedules currently supported)
Further options for const-cooldown:
--lr-cooldown-epochs M : cooldown for fixed number of M epochs after running const lr; eg if specifying total N epochs, there will be N-M epochs executed with const lr, followed by M epochs with cooldown schedule
--lr-cooldown-end val : cooling down to learning rate = val; default is 0
--lr-cooldown-power val : linear decay cooldown schedule for 1 (default); polynomial for > 1 values.
