### PR TITLE
[WIP] Support FSDP

### DIFF
--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -285,10 +285,10 @@ class CLIP(nn.Module):
 
         return F.normalize(x, dim=-1) if normalize else x
 
-    def forward(self, image, text, clamp_logit_scale_to=None):
+    def forward(self, image, text, clamp_logit_scale_to:float=0):
         image_features = self.encode_image(image, normalize=True) if image is not None else None
         text_features = self.encode_text(text, normalize=True) if text is not None else None
-        if clamp_logit_scale_to is not None:
+        if clamp_logit_scale_to:
             with torch.no_grad():
                 self.logit_scale.data.clamp_(0, clamp_logit_scale_to)
         if self.output_dict:

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -285,7 +285,7 @@ class CLIP(nn.Module):
 
         return F.normalize(x, dim=-1) if normalize else x
 
-    def forward(self, image, text, clamp_logit_scale_to:float=0):
+    def forward(self, image=None, text=None, clamp_logit_scale_to:float=0):
         image_features = self.encode_image(image, normalize=True) if image is not None else None
         text_features = self.encode_text(text, normalize=True) if text is not None else None
         if clamp_logit_scale_to:

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -356,10 +356,13 @@ class CustomTextCLIP(nn.Module):
             self,
             image: Optional[torch.Tensor] = None,
             text: Optional[torch.Tensor] = None,
+            clamp_logit_scale_to: float = 0,
     ):
         image_features = self.encode_image(image, normalize=True) if image is not None else None
         text_features = self.encode_text(text, normalize=True) if text is not None else None
-
+        if clamp_logit_scale_to:
+            with torch.no_grad():
+                self.logit_scale.data.clamp_(0, clamp_logit_scale_to)
         if self.output_dict:
             out_dict = {
                 "image_features": image_features,

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -285,14 +285,12 @@ class CLIP(nn.Module):
 
         return F.normalize(x, dim=-1) if normalize else x
 
-    def forward(
-            self,
-            image: Optional[torch.Tensor] = None,
-            text: Optional[torch.Tensor] = None,
-    ):
+    def forward(self, image, text, clamp_logit_scale_to=None):
         image_features = self.encode_image(image, normalize=True) if image is not None else None
         text_features = self.encode_text(text, normalize=True) if text is not None else None
-
+        if clamp_logit_scale_to is not None:
+            with torch.no_grad():
+                self.logit_scale.data.clamp_(0, clamp_logit_scale_to)
         if self.output_dict:
             out_dict = {
                 "image_features": image_features,

--- a/src/open_clip/zero_shot_classifier.py
+++ b/src/open_clip/zero_shot_classifier.py
@@ -53,7 +53,8 @@ def build_zero_shot_classifier(
         num_batch_classes = len(batch_classnames)
         texts = [template.format(c) if use_format else template(c) for c in batch_classnames for template in templates]
         texts = tokenizer(texts).to(device)
-        class_embeddings = model.encode_text(texts, normalize=True)
+        output = model(text=texts)
+        class_embeddings = output['text_features'] if isinstance(output, dict) else output[1]
         class_embeddings = class_embeddings.reshape(num_batch_classes, num_templates, -1).mean(dim=1)
         class_embeddings = class_embeddings / class_embeddings.norm(dim=1, keepdim=True)
         class_embeddings = class_embeddings.T

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -301,6 +301,7 @@ def main(args):
             if args.ddp_static_graph:
                 # this doesn't exist in older PyTorch, arg only added if enabled
                 ddp_args['static_graph'] = True
+            model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
         elif args.distributed_engine == 'fsdp':
             print(f"Before FSTP parameter num: {sum(p.numel() for p in model.parameters())}")
             print(f"Before FSDP {torch.cuda.memory_allocated()/1024**3:.3} GB")
@@ -310,16 +311,17 @@ def main(args):
                 # buffer_dtype=torch.bfloat16,
             )
             wrapper_kwargs = dict(
-                mixed_precision=mp,
-                limit_all_gathers=True,
-                auto_wrap_policy=partial(
-                   transformer_auto_wrap_policy,
-                   transformer_layer_cls={
-                       VisionTransformer,
-                       TextTransformer,
-                       CLIP,
-                   },
-                ),
+                #mixed_precision=mp,
+                #limit_all_gathers=True,
+                
+                #auto_wrap_policy=partial(
+                #   transformer_auto_wrap_policy,
+                #   transformer_layer_cls={
+                #       VisionTransformer,
+                #       TextTransformer,
+                #       CLIP,
+                #   },
+                #),
             )
             model = FSDP(model, device_id=device, **wrapper_kwargs)
             print(f"After FSTP parameter num: {sum(p.numel() for p in model.parameters())}")

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -302,6 +302,8 @@ def main(args):
                 # this doesn't exist in older PyTorch, arg only added if enabled
                 ddp_args['static_graph'] = True
         elif args.distributed_engine == 'fsdp':
+            print(f"Before FSTP parameter num: {sum(p.numel() for p in model.parameters())}")
+            print(f"Before FSDP {torch.cuda.memory_allocated()/1024**3:.3} GB")
             mp = MixedPrecision(
                 # param_dtype=torch.bfloat16,
                 reduce_dtype=torch.bfloat16,
@@ -310,13 +312,13 @@ def main(args):
             wrapper_kwargs = dict(
                 mixed_precision=mp,
                 limit_all_gathers=True,
-		        auto_wrap_policy=partial(
-                    transformer_auto_wrap_policy,
-                    transformer_layer_cls={
-                        VisionTransformer,
-                        TextTransformer,
-                        CLIP,
-                    },
+                auto_wrap_policy=partial(
+                   transformer_auto_wrap_policy,
+                   transformer_layer_cls={
+                       VisionTransformer,
+                       TextTransformer,
+                       CLIP,
+                   },
                 ),
             )
             model = FSDP(model, device_id=device, **wrapper_kwargs)

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -317,14 +317,14 @@ def main(args):
             )
             wrapper_kwargs = dict(
                 mixed_precision=mp,
-                limit_all_gathers=True,
+                limit_all_gathers=args.fsdp_limit_allgathers,
                 cpu_offload=CPUOffload(offload_params=args.fsdp_cpu_offload),
                 auto_wrap_policy=partial(
                    transformer_auto_wrap_policy,
                    transformer_layer_cls={
                        VisionTransformer,
                        TextTransformer,
-                       CLIP,
+                       ResidualAttentionBlock,
                    },
                 ),
                 device_id=None if args.fsdp_init_on_cpu else device,

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -315,7 +315,7 @@ def main(args):
         if args.fsdp:
             if is_master(args):
                 logging.info(f"Before FSDP number of params: {sum(p.numel() for p in model.parameters())}")
-                logging.info(f"Before FSDP memory allocated: {torch.cuda.memory_allocated()/1024**3:.3} GB")
+                logging.info(f"Before FSDP memory allocated: {torch.cuda.memory_allocated()/1024**3:.4} GB")
             type_name_to_class = {
                 "amp": torch.float16,
                 "amp_bf16": torch.bfloat16,
@@ -356,7 +356,7 @@ def main(args):
             model = FSDP(model, **wrapper_kwargs)
             if is_master(args):
                 logging.info(f"After FSDP number of params: {sum(p.numel() for p in model.parameters())}")
-                logging.info(f"After FSDP memory allocated: {torch.cuda.memory_allocated()/1024**3:.3} GB")
+                logging.info(f"After FSDP memory allocated: {torch.cuda.memory_allocated()/1024**3:.4} GB")
             if args.grad_checkpointing:
                 layers_grad_checkpoint = set()
                 for module in model.modules():

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -334,7 +334,9 @@ def main(args):
                 for layer in args.fsdp_layers_to_wrap:
                     if re.match(layer, name):
                         layers.add(module.__class__)
-            logging.info(f"FSDP Wrapped layers: {layers}")
+
+            if is_master(args):
+                logging.info(f"FSDP Wrapped layers: {layers}")
 
             wrapper_kwargs = dict(
                 mixed_precision=mixed_precision,
@@ -357,6 +359,7 @@ def main(args):
             if is_master(args):
                 logging.info(f"After FSDP number of params: {sum(p.numel() for p in model.parameters())}")
                 logging.info(f"After FSDP memory allocated: {torch.cuda.memory_allocated()/1024**3:.4} GB")
+                
             if args.grad_checkpointing:
                 layers_grad_checkpoint = set()
                 for module in model.modules():

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -309,6 +309,9 @@ def main(args):
                 wrap,
             )
             print(f"Before FSTP parameter num: {sum(p.numel() for p in model.parameters())}")
+            print(f"Before FSTP VISUAL parameter num: {sum(p.numel() for p in model.visual.parameters())}")
+            #print(f"Before FSTP TEXT parameter num: {sum(p.numel() for p in model.transformer.parameters())}")
+
             print(f"Before FSDP {torch.cuda.memory_allocated()/1024**3:.3} GB")
             mp = MixedPrecision(
                 #param_dtype=torch.bfloat16,
@@ -327,7 +330,7 @@ def main(args):
                        ResidualAttentionBlock,
                    },
                 ),
-                device_id=None if args.fsdp_init_on_cpu else device,
+                device_id=device,
             )
 
             # avoid "RuntimeError: The tensor has a non-zero number of elements, but its data is not allocated yet. Caffe2 uses a lazy allocation, so you will need to call mutable_data() or raw_mutable_data() to actually allocate memory."

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -304,6 +304,8 @@ def main(args):
                 # this doesn't exist in older PyTorch, arg only added if enabled
                 ddp_args['static_graph'] = True
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
+            if args.distill:
+                dist_model = torch.nn.parallel.DistributedDataParallel(dist_model, device_ids=[device], **ddp_args)
         elif args.distributed_engine == 'fsdp':
             from torch.distributed.fsdp.wrap import (
                 enable_wrap,

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -325,7 +325,7 @@ def main(args):
             }
             mixed_precision = MixedPrecision(
                 param_dtype=type_name_to_class[args.precision],
-                reduce_dtype=type_name_to_class[args.fsdp_reduce_precision],
+                reduce_dtype=type_name_to_class[args.fsdp_gradient_reduction_precision],
                 buffer_dtype=type_name_to_class[args.fsdp_buffer_precision],
             )
             layers = set()
@@ -453,8 +453,8 @@ def main(args):
         FSDP.set_state_dict_type(
             model,
             StateDictType.FULL_STATE_DICT,
-            FullStateDictConfig(rank0_only=False, offload_to_cpu=True),
-            FullOptimStateDictConfig(rank0_only=False, offload_to_cpu=True),
+            FullStateDictConfig(rank0_only=True, offload_to_cpu=True),
+            FullOptimStateDictConfig(rank0_only=True, offload_to_cpu=True),
         )
     # initialize datasets
     tokenizer = get_tokenizer(args.model)

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -548,7 +548,7 @@ def main(args):
             checkpoint_dict = {
                 "epoch": completed_epoch,
                 "name": args.name,
-                "state_dict": model.state_dict(),
+                "state_dict": original_model.state_dict(),
                 "optimizer": FSDP.optim_state_dict(model, optimizer) if args.fsdp else optimizer.state_dict(),
             }
 

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -41,6 +41,7 @@ from training.train import train_one_epoch, evaluate
 from training.file_utils import pt_load, check_exists, start_sync_process, remote_sync
 
 
+
 LATEST_CHECKPOINT_NAME = "epoch_latest.pt"
 
 
@@ -69,7 +70,6 @@ def get_latest_checkpoint(path: str, remote : bool):
         checkpoints = sorted(checkpoints, key=natural_key)
         return checkpoints[-1]
     return None
-
 
 def main(args):
     args = parse_args(args)
@@ -323,6 +323,7 @@ def main(args):
                     if re.match(layer, name):
                         layers.add(module.__class__)
             print("Wrapped layers", layers)
+
             wrapper_kwargs = dict(
                 mixed_precision=mp,
                 limit_all_gathers=args.fsdp_limit_allgathers,
@@ -340,9 +341,6 @@ def main(args):
             #model.visual = FSDP(model.visual, device_id=device)
             #model.text_projection = FSDP(model.text_projection) ???
             #model.ln_final = FSDP(model.ln_final, device_id=device)
-            model = FSDP(model, **wrapper_kwargs)
-            print(f"After FSTP parameter num: {sum(p.numel() for p in model.parameters())}")
-            print(f"After FSDP {torch.cuda.memory_allocated()/1024**3:.3} GB")
             if args.lock_image:
                 # lock image tower as per LiT - https://arxiv.org/abs/2111.07991
                 model.lock_image_tower(
@@ -352,6 +350,9 @@ def main(args):
                 model.lock_text_tower(
                     unlocked_layers=args.lock_text_unlocked_layers,
                     freeze_layer_norm=args.lock_text_freeze_layer_norm)
+            model = FSDP(model, **wrapper_kwargs)
+            print(f"After FSTP parameter num: {sum(p.numel() for p in model.parameters())}")
+            print(f"After FSDP {torch.cuda.memory_allocated()/1024**3:.3} GB")
             if args.grad_checkpointing:
                 #https://pytorch.org/blog/efficient-large-scale-training-with-pytorch/
                 layers_grad_checkpoint = set()
@@ -374,8 +375,6 @@ def main(args):
                 apply_activation_checkpointing(
                     model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=check_fn
                 )
-
-
         else:
             print("--distrubted_engine should be either 'ddp or 'fsdp'")
             sys.exit(1)
@@ -409,7 +408,6 @@ def main(args):
             hvd.broadcast_optimizer_state(optimizer, root_rank=0)
 
         scaler = GradScaler() if args.precision == "amp" else None
-
     # optionally resume from a checkpoint
     start_epoch = 0
     if args.resume is not None:
@@ -430,7 +428,6 @@ def main(args):
             # loading a bare (model only) checkpoint for fine-tune or evaluation
             model.load_state_dict(checkpoint)
             logging.info(f"=> loaded checkpoint '{args.resume}' (epoch {start_epoch})")
-
     # initialize datasets
     tokenizer = get_tokenizer(args.model)
     data = get_data(
@@ -460,9 +457,8 @@ def main(args):
             logging.error(
                 f'Unknown scheduler, {args.lr_scheduler}. Available options are: cosine, const, const-cooldown.')
             exit(1)
-
     # determine if this worker should save logs and checkpoints. only do so if it is rank == 0
-    args.save_logs = args.logs and args.logs.lower() != 'none' and is_master(args)
+    args.save_logs = args.logs and args.logs.lower() != 'none' and (is_master(args) or args.distributed_engine == 'fsdp')
     writer = None
     if args.save_logs and args.tensorboard:
         assert tensorboard is not None, "Please install tensorboard."
@@ -507,11 +503,9 @@ def main(args):
         return
 
     loss = create_loss(args)
-
     for epoch in range(start_epoch, args.epochs):
         if is_master(args):
             logging.info(f'Start epoch {epoch}')
-
         train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist_model, args, tb_writer=writer)
         completed_epoch = epoch + 1
 
@@ -528,25 +522,25 @@ def main(args):
             }
             if scaler is not None:
                 checkpoint_dict["scaler"] = scaler.state_dict()
+            if is_master(args):
+                if completed_epoch == args.epochs or (
+                    args.save_frequency > 0 and (completed_epoch % args.save_frequency) == 0
+                ):
+                    torch.save(
+                        checkpoint_dict,
+                        os.path.join(args.checkpoint_path, f"epoch_{completed_epoch}.pt"),
+                    )
+                if args.delete_previous_checkpoint:
+                    previous_checkpoint = os.path.join(args.checkpoint_path, f"epoch_{completed_epoch - 1}.pt")
+                    if os.path.exists(previous_checkpoint):
+                        os.remove(previous_checkpoint)
 
-            if completed_epoch == args.epochs or (
-                args.save_frequency > 0 and (completed_epoch % args.save_frequency) == 0
-            ):
-                torch.save(
-                    checkpoint_dict,
-                    os.path.join(args.checkpoint_path, f"epoch_{completed_epoch}.pt"),
-                )
-            if args.delete_previous_checkpoint:
-                previous_checkpoint = os.path.join(args.checkpoint_path, f"epoch_{completed_epoch - 1}.pt")
-                if os.path.exists(previous_checkpoint):
-                    os.remove(previous_checkpoint)
-
-            if args.save_most_recent:
-                # try not to corrupt the latest checkpoint if save fails
-                tmp_save_path = os.path.join(args.checkpoint_path, "tmp.pt")
-                latest_save_path = os.path.join(args.checkpoint_path, LATEST_CHECKPOINT_NAME)
-                torch.save(checkpoint_dict, tmp_save_path)
-                os.replace(tmp_save_path, latest_save_path)
+                if args.save_most_recent:
+                    # try not to corrupt the latest checkpoint if save fails
+                    tmp_save_path = os.path.join(args.checkpoint_path, "tmp.pt")
+                    latest_save_path = os.path.join(args.checkpoint_path, LATEST_CHECKPOINT_NAME)
+                    torch.save(checkpoint_dict, tmp_save_path)
+                    os.replace(tmp_save_path, latest_save_path)
 
     if args.wandb and is_master(args):
         wandb.finish()

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -370,16 +370,19 @@ def parse_args(args):
         "--fsdp-init-on-cpu",
         default=False,
         action="store_true",
+        help="Initialize the model on CPUs rather than GPUs, useful for large models",
     )
     parser.add_argument(
         "--fsdp-cpu-offload",
         default=False,
         action="store_true",
+        help="Use CPU offloading",
     )
     parser.add_argument(
         "--fsdp-limit-allgathers",
         default=False,
         action="store_true",
+        help="Prevent too many allgathers",
     )
     parser.add_argument(
         "--fsdp-layers-to-wrap",
@@ -398,7 +401,8 @@ def parse_args(args):
             'TimmModel',
         ),
         type=str,
-        nargs='+'
+        nargs='+',
+        help="Regular expression to match module names to wrap in FSDP, this affects communication and peak memory.",
     )
     parser.add_argument(
         "--fsdp-layers-to-grad-checkpoint",
@@ -407,7 +411,8 @@ def parse_args(args):
             'Bottleneck',
         ),
         type=str,
-        nargs='+'
+        nargs='+',
+        help="Module names to wrap for gradient checkpointing when FSDP is used",
     )
     parser.add_argument(
         "--fsdp-buffer-precision",
@@ -421,7 +426,6 @@ def parse_args(args):
         default="fp16",
         help="FSDP floating point precision for gradient reduction"
     )
-
     parser.add_argument(
         "--no-set-device-rank",
         default=False,

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -361,10 +361,10 @@ def parse_args(args):
         help="Enable static graph optimization for DDP in PyTorch >= 1.11.",
     )
     parser.add_argument(
-        "--distributed-engine",
-        type=str,
-        default="ddp",
-        choices=["ddp", "fsdp"],
+        "--fsdp",
+        default=False,
+        action="store_true",
+        help="Use FSDP for distributed training."
     )
     parser.add_argument(
         "--fsdp-init-on-cpu",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -415,12 +415,6 @@ def parse_args(args):
         help="Module names to wrap for gradient checkpointing when FSDP is used",
     )
     parser.add_argument(
-        "--fsdp-buffer-precision",
-        choices=["bf16", "fp16", "fp32"],
-        default="fp32",
-        help="FSDP floating point precision for buffers"
-    )
-    parser.add_argument(
         "--fsdp-gradient-reduction-precision",
         choices=["bf16", "fp16", "fp32"],
         default="fp16",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -373,6 +373,12 @@ def parse_args(args):
         help="Initialize the model on CPUs rather than GPUs, useful for large models",
     )
     parser.add_argument(
+        "--fsdp-use-distributed-checkpointer",
+        default=False,
+        action="store_true",
+        help="Use distributed checkpointer for FSDP, useful for large models",
+    )
+    parser.add_argument(
         "--fsdp-cpu-offload",
         default=False,
         action="store_true",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -375,6 +375,11 @@ def parse_args(args):
         action="store_true",
     )
     parser.add_argument(
+        "--fsdp-limit-allgathers",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
         "--no-set-device-rank",
         default=False,
         action="store_true",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -416,7 +416,7 @@ def parse_args(args):
         help="FSDP floating point precision for buffers"
     )
     parser.add_argument(
-        "--fsdp-reduce-precision",
+        "--fsdp-gradient-reduction-precision",
         choices=["bf16", "fp16", "fp32"],
         default="fp16",
         help="FSDP floating point precision for gradient reduction"

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -23,6 +23,8 @@ class ParseKwargs(argparse.Action):
         setattr(namespace, self.dest, kw)
 
 
+
+
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -378,6 +380,34 @@ def parse_args(args):
         "--fsdp-limit-allgathers",
         default=False,
         action="store_true",
+    )
+    parser.add_argument(
+        "--fsdp-layers-to-wrap",
+        default=(
+            # Match all sort of blocks
+            '.*Block.*',
+            'Bottleneck',
+            # CLIP
+            'VisionTransformer', 
+            'Transformer', 
+            # CLIP ModifiedResNet
+            'ModifiedResNet',
+            # HF Text
+            'HFTextEncoder',
+            # TIMM visual
+            'TimmModel',
+        ),
+        type=str,
+        nargs='+'
+    )
+    parser.add_argument(
+        "--fsdp-layers-to-grad-checkpoint",
+        default=(
+            '.*Block.*',
+            'Bottleneck',
+        ),
+        type=str,
+        nargs='+'
     )
     parser.add_argument(
         "--no-set-device-rank",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -359,10 +359,20 @@ def parse_args(args):
         help="Enable static graph optimization for DDP in PyTorch >= 1.11.",
     )
     parser.add_argument(
-        "--distributed_engine",
+        "--distributed-engine",
         type=str,
         default="ddp",
         choices=["ddp", "fsdp"],
+    )
+    parser.add_argument(
+        "--fsdp-init-on-cpu",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--fsdp-cpu-offload",
+        default=False,
+        action="store_true",
     )
     parser.add_argument(
         "--no-set-device-rank",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -359,6 +359,12 @@ def parse_args(args):
         help="Enable static graph optimization for DDP in PyTorch >= 1.11.",
     )
     parser.add_argument(
+        "--distributed_engine",
+        type=str,
+        default="ddp",
+        choices=["ddp", "fsdp"],
+    )
+    parser.add_argument(
         "--no-set-device-rank",
         default=False,
         action="store_true",

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -410,6 +410,19 @@ def parse_args(args):
         nargs='+'
     )
     parser.add_argument(
+        "--fsdp-buffer-precision",
+        choices=["bf16", "fp16", "fp32"],
+        default="fp32",
+        help="FSDP floating point precision for buffers"
+    )
+    parser.add_argument(
+        "--fsdp-reduce-precision",
+        choices=["bf16", "fp16", "fp32"],
+        default="fp16",
+        help="FSDP floating point precision for gradient reduction"
+    )
+
+    parser.add_argument(
         "--no-set-device-rank",
         default=False,
         action="store_true",

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -185,8 +185,8 @@ def train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist
             accum_images, accum_texts, accum_features = [], [], {}
 
         # Note: we clamp to 4.6052 = ln(100), as in the original paper.
-        with torch.no_grad():
-            unwrap_model(model).logit_scale.clamp_(0, math.log(100))
+        #with torch.no_grad():
+        #    unwrap_model(model).logit_scale.clamp_(0, math.log(100))
 
         batch_time_m.update(time.time() - end)
         end = time.time()

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -338,7 +338,7 @@ def evaluate(model, data, epoch, args, tb_writer=None, tokenizer=None):
 
     log_data = {"val/" + name: val for name, val in metrics.items()}
 
-    if args.save_logs:
+    if args.save_logs and is_master(args):
         if tb_writer is not None:
             for name, val in log_data.items():
                 tb_writer.add_scalar(name, val, epoch)
@@ -347,7 +347,7 @@ def evaluate(model, data, epoch, args, tb_writer=None, tokenizer=None):
             f.write(json.dumps(metrics))
             f.write("\n")
 
-    if args.wandb:
+    if args.wandb and is_master(args):
         assert wandb is not None, 'Please install wandb.'
         if 'train' in data:
             dataloader = data['train'].dataloader

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parallel.distributed import DistributedDataParallel
 
+
 try:
     import wandb
 except ImportError:
@@ -185,7 +186,7 @@ def train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist
             accum_images, accum_texts, accum_features = [], [], {}
 
         # Note: we clamp to 4.6052 = ln(100), as in the original paper.
-        if args.distributed_engine == 'fsdp':
+        if args.fsdp:
             model(image=None, text=None, clamp_logit_scale_to=math.log(100))
         else:
             with torch.no_grad():
@@ -253,7 +254,7 @@ def train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist
 
 def evaluate(model, data, epoch, args, tb_writer=None, tokenizer=None):
     metrics = {}
-    if not is_master(args) and args.distributed_engine != 'fsdp':
+    if not is_master(args) and not args.fsdp:
         return metrics
     device = torch.device(args.device)
     model.eval()

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -17,7 +17,7 @@ def zero_shot_classifier(model, classnames, templates, args):
             texts = [template(classname) for template in templates]  # format with class
             texts = tokenizer(texts).to(args.device)  # tokenize
             if args.distributed and not args.horovod:
-                if args.distributed_engine == 'fsdp':
+                if args.fsdp:
                     _, class_embeddings, _ = model(image=None, text=texts)
                 else:
                     class_embeddings = model.module.encode_text(texts)
@@ -49,7 +49,7 @@ def run(model, classifier, dataloader, args):
             with autocast():
                 # predict
                 if args.distributed and not args.horovod:
-                    if args.distributed_engine == 'fsdp':
+                    if args.fsdp:
                         image_features, _, _ = model(image=images, text=None)
                     else:
                         image_features = model.module.encode_image(images)

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -6,7 +6,6 @@ from tqdm import tqdm
 from open_clip import get_input_dtype, get_tokenizer, build_zero_shot_classifier, \
     IMAGENET_CLASSNAMES, OPENAI_IMAGENET_TEMPLATES
 from .precision import get_autocast
-from .imagenet_zeroshot_data import imagenet_classnames, openai_imagenet_template
 
 
 def zero_shot_classifier(model, classnames, templates, args):

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -8,27 +8,6 @@ from open_clip import get_input_dtype, get_tokenizer, build_zero_shot_classifier
 from .precision import get_autocast
 
 
-def zero_shot_classifier(model, classnames, templates, args):
-    tokenizer = get_tokenizer(args.model)
-    with torch.no_grad():
-        zeroshot_weights = []
-        for classname in tqdm(classnames):
-            texts = [template(classname) for template in templates]  # format with class
-            texts = tokenizer(texts).to(args.device)  # tokenize
-            if args.distributed and not args.horovod:
-                if args.fsdp:
-                    _, class_embeddings, _ = model(image=None, text=texts)
-                else:
-                    class_embeddings = model.module.encode_text(texts)
-            else:
-                class_embeddings = model.encode_text(texts)
-            class_embedding = F.normalize(class_embeddings, dim=-1).mean(dim=0)
-            class_embedding /= class_embedding.norm()
-            zeroshot_weights.append(class_embedding)
-        zeroshot_weights = torch.stack(zeroshot_weights, dim=1).to(args.device)
-    return zeroshot_weights
-
-
 def accuracy(output, target, topk=(1,)):
     pred = output.topk(max(topk), 1, True, True)[1].t()
     correct = pred.eq(target.view(1, -1).expand_as(pred))


### PR DESCRIPTION
This PR adds FSDP (https://pytorch.org/docs/stable/fsdp.html) support for training large models than cannot
fit in memory.

The code works already, but still need to be improved, so this is still a draft.

Some scaling plots with sample per sec per gpu, done on JUWELS Booster.

G-14:
![G-14](https://user-images.githubusercontent.com/509507/212936174-e0d247dc-f04b-4982-a153-757719bd3513.png)

X-14 (15B visual, 5B text):
![X-14](https://user-images.githubusercontent.com/509507/212936198-d3a8ea10-d37a-4b58-af76-81e76ecb2c1c.png)

I also tried G-14 as visual encoder together with a  pre-trained T5-XXL as text encoder.

Putting again some remarks and possible improvements, discussed earlier in discord:

- I see some hanging issues starting from large number of nodes (256 nodes, 1024 GPUs onJUWELS Booster), no single iteration,  I don't see anything special on NCCL debugging info except that it does a lot of `all_gather`,
which is expected from FSDP
- CPU offloading and gradient checkpointing are supported
- each time `encode_image` or `encode_text` or `logit_scale` were accessed without going through the forward function (so happens when clipping logit scale, or at evaluation), an exception was raised (see https://github.com/pytorch/pytorch/issues/82461 for reference). The workaround I found is to modify the forward function so that it is possible to encode both text and image (as currently done), or text only, or image only, or use it for clipping logit scale. It would be  better if we find a cleaner solution. The solution provided by the issue in pytorch above is to wrap the modules (here text and image encoders)  using FSDP, but we need then to change some internals, as  part of  the text encoder cannot be wrapped as it is an `nn.Parameter`, FSDP  needs an `nn.Module`. We could use `CustomTextCLIP` to wrap the text encoder in its entirty as proposed by @rwightman, then we need to deal with `logit_scale`.
-  The list of layers to FSDP-wrap is important as it affects the peak memory (documented here https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html#id2) and the layer names are model dependent. e.g. in T5, I am FSDP wrapping T5Block, and in CLIP class of I am wrapping ResidualAttentionBlock. So we need a way to parametrize this, for the moment they are hardcoded. If we just use the default auto policy of FSDP, we get OOM.
