### PR TITLE
better torchscript and small test refactor

### DIFF
--- a/src/open_clip/hf_model.py
+++ b/src/open_clip/hf_model.py
@@ -81,7 +81,7 @@ class ClsPooler(nn.Module):
 
 class HFTextEncoder(nn.Module):
     """HuggingFace model adapter"""
-
+    output_tokens: torch.jit.Final[bool]
     def __init__(
             self,
             model_name_or_path: str,
@@ -93,9 +93,7 @@ class HFTextEncoder(nn.Module):
             output_tokens: bool = False
         ):
         super().__init__()
-        self.output_tokens = None
-        if output_tokens:
-            self.output_tokens = output_tokens
+        self.output_tokens = output_tokens
         self.output_dim = output_dim
 
         # TODO: find better way to get this information
@@ -147,7 +145,7 @@ class HFTextEncoder(nn.Module):
             else out.last_hidden_state
         )
         
-        if self.output_tokens is not None:
+        if self.output_tokens:
             return projected, tokens
         return projected
 

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -172,6 +172,7 @@ def _build_text_tower(
 
 
 class CLIP(nn.Module):
+    output_dict: torch.jit.Final[bool]
     def __init__(
             self,
             embed_dim: int,
@@ -182,9 +183,7 @@ class CLIP(nn.Module):
             output_dict: bool = False
     ):
         super().__init__()
-        self.output_dict = None
-        if output_dict:
-            self.output_dict = output_dict
+        self.output_dict = output_dict
         self.visual = _build_vision_tower(embed_dim, vision_cfg, quick_gelu, cast_dtype)
 
         text = _build_text_tower(embed_dim, text_cfg, quick_gelu, cast_dtype)
@@ -228,7 +227,7 @@ class CLIP(nn.Module):
     def forward(self, image, text):
         image_features = self.encode_image(image, normalize=True)
         text_features = self.encode_text(text, normalize=True)
-        if self.output_dict is not None:
+        if self.output_dict:
             return {
                 "image_features":image_features, 
                 "text_features":text_features,
@@ -238,6 +237,7 @@ class CLIP(nn.Module):
 
 
 class CustomTextCLIP(nn.Module):
+    output_dict: torch.jit.Final[bool]
     def __init__(
             self,
             embed_dim: int,
@@ -248,9 +248,7 @@ class CustomTextCLIP(nn.Module):
             output_dict: bool = False
     ):
         super().__init__()
-        self.output_dict = None
-        if output_dict:
-            self.output_dict = output_dict
+        self.output_dict = output_dict
         self.visual = _build_vision_tower(embed_dim, vision_cfg, quick_gelu, cast_dtype)
         self.text = _build_text_tower(embed_dim, text_cfg, quick_gelu, cast_dtype)
         self.logit_scale = nn.Parameter(torch.ones([]) * np.log(1 / 0.07))
@@ -278,7 +276,7 @@ class CustomTextCLIP(nn.Module):
     def forward(self, image, text):
         image_features = self.encode_image(image, normalize=True)
         text_features = self.encode_text(text, normalize=True)
-        if self.output_dict is not None:
+        if self.output_dict:
             return {
                 "image_features":image_features, 
                 "text_features":text_features,

--- a/src/open_clip/transformer.py
+++ b/src/open_clip/transformer.py
@@ -320,6 +320,7 @@ class Transformer(nn.Module):
 
 
 class VisionTransformer(nn.Module):
+    output_tokens: torch.jit.Final[bool]
     def __init__(
             self,
             image_size: int,
@@ -340,9 +341,7 @@ class VisionTransformer(nn.Module):
             output_tokens: bool = False
     ):
         super().__init__()
-        self.output_tokens = None
-        if output_tokens:
-            self.output_tokens = output_tokens
+        self.output_tokens = output_tokens
         self.image_size = to_2tuple(image_size)
         self.patch_size = to_2tuple(patch_size)
         self.grid_size = (self.image_size[0] // self.patch_size[0], self.image_size[1] // self.patch_size[1])
@@ -467,14 +466,14 @@ class VisionTransformer(nn.Module):
         if self.proj is not None:
             pooled = pooled @ self.proj
 
-        if self.output_tokens is not None:
+        if self.output_tokens:
             return pooled, tokens
         
         return pooled
 
 
 class TextTransformer(nn.Module):
-
+    output_tokens: torch.jit.Final[bool]
     def __init__(
             self,
             context_length: int = 77,
@@ -491,9 +490,7 @@ class TextTransformer(nn.Module):
             output_tokens: bool = False
     ):
         super().__init__()
-        self.output_tokens = None
-        if output_tokens:
-            self.output_tokens = output_tokens
+        self.output_tokens = output_tokens
         self.context_length = context_length
         self.vocab_size = vocab_size
         self.width = width
@@ -597,7 +594,7 @@ class TextTransformer(nn.Module):
         if self.text_projection is not None:
             pooled = pooled @ self.text_projection
 
-        if self.output_tokens is not None:
+        if self.output_tokens:
             return pooled, tokens
         
         return pooled

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -49,27 +49,6 @@ models_to_jit_test = [(model_name, True) for model_name in models_to_jit_test]
 models_to_test_fully = models_to_test + models_to_jit_test
 
 
-class TestWrapper(torch.nn.Module):
-    def __init__(self, model, model_name, output_dict=True) -> None:
-        super().__init__()
-        self.model = model
-        self.output_dict = None
-        if output_dict:
-            self.output_dict = output_dict
-        if type(model) in [open_clip.CLIP, open_clip.CustomTextCLIP]:
-            self.model.output_dict = self.output_dict
-        config = open_clip.get_model_config(model_name)
-        self.head = torch.nn.Linear(config["embed_dim"], 2)
-
-    def forward(self, image, text):
-        output_dict = self.output_dict
-        x = self.model(image, text)
-        if output_dict is not None:
-            out = self.head(x["image_features"])
-        else:
-            out = self.head(x[0])
-        return {"test_output": out}
-
 @pytest.mark.regression_test
 @pytest.mark.parametrize("model_name,jit", models_to_test_fully)
 def test_inference_with_data(
@@ -139,12 +118,12 @@ def test_inference_with_data(
             pretrained_hf = pretrained_hf
         )
         
-        test_model = TestWrapper(model, model_name, output_dict=False)
+        test_model = util_test.TestWrapper(model, model_name, output_dict=False)
         test_model = torch.jit.script(test_model)
         model_out = util_test.forward_model(test_model, model_name, preprocess_val, input_image, input_text)
         assert model_out["test_output"].shape[-1] == 2
 
-        test_model = TestWrapper(model, model_name, output_dict=True)
+        test_model = util_test.TestWrapper(model, model_name, output_dict=True)
         test_model = torch.jit.script(test_model)
         model_out = util_test.forward_model(test_model, model_name, preprocess_val, input_image, input_text)
         assert model_out["test_output"].shape[-1] == 2


### PR DESCRIPTION
@rwightman @iejMac @rom1504 

@rwightman was saying that booleans should be ok for torchscript, if I understand they are but to avoid checking all branches output the same thing one needs to make them constants https://pytorch.org/docs/stable/jit_language_reference.html#python-defined-constants 

In this PR I annotate them as constants and it seems to work. Let me know if this is ok and thank you for all the reviews