### PR TITLE
Fetch from Hugging Face Hub using hf_hub: prefix

### DIFF
--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -200,7 +200,7 @@ def create_model(
                     f'Available pretrained tags ({list_pretrained_tags_by_model(model_name)}.')
                 logging.warning(error_str)
                 raise RuntimeError(error_str)
-        else:
+        elif model_name.startswith(hf_hub_prefix):
             logging.info(f'Loading pretrained {model_name} weights ({pretrained}).')
             load_checkpoint(model, checkpoint_path)
 

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -78,21 +78,20 @@ def main(args):
         torch.backends.cudnn.benchmark = True
         torch.backends.cudnn.deterministic = False
 
-    # sanitize model name for filesystem / uri use, easier if we don't use / in name as a rule?
-    args.model = args.model.replace('/', '-')
-
     # fully initialize distributed device environment
     device = init_distributed_device(args)
 
     # get the name of the experiments
     if args.name is None:
-        date_str = datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
+        # sanitize model name for filesystem / uri use, easier if we don't use / in name as a rule?
+        model_name_safe = args.model.replace('/', '-')
+        date_str = datetime.now().strftime("%Y_%m_%d`-%H_%M_%S")
         if args.distributed:
             # sync date_str from master to all ranks
             date_str = broadcast_object(args, date_str)
         args.name = '-'.join([
             date_str,
-            f"model_{args.model}",
+            f"model_{model_name_safe}",
             f"lr_{args.lr}",
             f"b_{args.batch_size}",
             f"j_{args.workers}",


### PR DESCRIPTION
Adds the option to load any model hosted on the hub using the `hf-hub:` prefix.

For this to work, the model repositories would need an `open_clip_config.json` file uploaded with the configuration values currently hosted in json file in this repository.

Here's an example of a working repository: https://huggingface.co/lysandre/CLIP-ViT-L-14-laion2B-s32B-b82K

Here's how this would be used in practice:

```py
import open_clip

model, _, preprocess = open_clip.create_model_and_transforms('hf-hub:lysandre/CLIP-ViT-L-14-laion2B-s32B-b82K')
tokenizer = open_clip.get_tokenizer('hf-hub:lysandre/CLIP-ViT-L-14-laion2B-s32B-b82K')
```

fix https://github.com/mlfoundations/open_clip/issues/290