### PR TITLE
Unescessary log on relative path

### DIFF
--- a/src/training/file_utils.py
+++ b/src/training/file_utils.py
@@ -67,7 +67,7 @@ def pt_save(pt_obj, file_path):
         torch.save(pt_obj, file_path)
 
 def pt_load(file_path, map_location=None):
-    if not file_path.startswith('/'):
+    if file_path.startswith('s3'):
         logging.info('Loading remote checkpoint, which may take a bit.')
     of = fsspec.open(file_path, "rb")
     with of as f:


### PR DESCRIPTION
Jenia pointed out that s3 log message unnecessary prints on relative paths