### PR TITLE
[WIP] Add support for dataset mixtures with different sampling weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ You can set this on your visual transformer config with the key `patch_dropout`.
 
 In the paper, they also finetuned without the patch dropout at the end. You can do this with the command-line argument `--force-patch-dropout 0.`
 
+#### Multiple data sources
+
+OpenCLIP supports using multiple data sources, by separating different data paths with `::`.
+For instance, to train on CC12M and on LAION, one might use `--train-data '/data/cc12m/cc12m-train-{0000..2175}.tar'::/data/LAION-400M/{00000..41455}.tar"`.
+Using `--dataset-resampled` is recommended for these cases.
+
+By default, on expectation the amount of times the model will see a sample from each source is proportional to the size of the source.
+For instance, when training on one data source with size 400M and one with size 10M, samples from the first source are 40x more likely to be seen in expectation.
+
+We also support different weighting of the data sources, by using the `--train-data-weights` flag.
+For instance, using `--train-data-weights=1::1` in the above scenario will make it so that samples from each data source are equally likely to be seen in expectation. 
+
 #### Single-Node
 
 We make use of `torchrun` to launch distributed jobs. The following launches a

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -71,25 +71,6 @@ class DataInfo:
             self.sampler.set_epoch(epoch)
 
 
-def expand_urls(urls, weights=None):
-    if isinstance(urls, str):
-        urllist = urls.split("::")
-        if weights is None:
-            weights = [1 for _ in urllist]
-        else:
-            weights = weights.split('::')
-            assert len(weights) == len(urllist), f"Expected the number of data components ({len(urllist)}) and weights({len(weights)}) to match."
-            weights = [float(weight) for weight in weights]
-        all_urls, all_weights = [], []
-        for url, weight in zip(urllist, weights):
-            expanded_url = braceexpand.braceexpand(url)
-            all_urls.extend(expanded_url)
-            all_weights.extend([weight for _ in expanded_url])
-        return all_urls, all_weights
-    else:
-        return list(urls), weights
-
-
 def get_dataset_size(shards):
     shards_list = wds.shardlists.expand_urls(shards)
     dir_path = os.path.dirname(shards_list[0])

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -422,8 +422,4 @@ def parse_args(args):
         if getattr(args, name) is None:
             setattr(args, name, val)
 
-    if args.train_data.startswith('s3'):
-        components = args.train_data.split('::')
-        args.train_data = '::'.join([f'pipe:aws s3 cp {c} -' for c in components])
-
     return args

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -35,7 +35,11 @@ def parse_args(args):
         "--train-data-weights",
         type=str,
         default=None,
-        help="When using multiple data sources with webdataset and sampling with replacement, which weight to use for sampling the different data sources. Similar to --train-data, this should be a string with as many numbers as there are data sources, separated by `::` (e.g. 1::2::0.5)",
+        help=(
+            "When using multiple data sources with webdataset and sampling with replacement, which weight to use for sampling the different data sources. "
+            "Similar to --train-data, this should be a string with as many numbers as there are data sources, separated by `::` (e.g. 1::2::0.5) "
+            "By default, datapoints are sampled uniformly regardless of the dataset sizes."
+        )
     )
     parser.add_argument(
         "--val-data",
@@ -417,5 +421,9 @@ def parse_args(args):
     for name, val in default_params.items():
         if getattr(args, name) is None:
             setattr(args, name, val)
+
+    if args.train_data.startswith('s3'):
+        components = args.train_data.split('::')
+        args.train_data = '::'.join([f'pipe:aws s3 cp {c} -' for c in components])
 
     return args

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -29,7 +29,13 @@ def parse_args(args):
         "--train-data",
         type=str,
         default=None,
-        help="Path to file(s) with training data",
+        help="Path to file(s) with training data. When using webdataset, multiple datasources can be combined using the `::` separator.",
+    )
+    parser.add_argument(
+        "--train-data-weights",
+        type=str,
+        default=None,
+        help="When using multiple data sources with webdataset and sampling with replacement, which weight to use for sampling the different data sources. Similar to --train-data, this should be a string with as many numbers as there are data sources, separated by `::` (e.g. 1::2::0.5)",
     )
     parser.add_argument(
         "--val-data",


### PR DESCRIPTION
When using multiple data sources (e.g. `--train-data=path/to/dir/1/{000..999}.tar::path/to/dir/2/{000..999}.tar`), allow the different sources to be sampled with different weights (e.g. by using `train-data-weights=100::1`)