### PR TITLE
fix accum-grad training

### DIFF
--- a/tests/test_training_simple.py
+++ b/tests/test_training_simple.py
@@ -81,7 +81,8 @@ def test_training_unfreezing_vit():
     '--workers', '2',
     '--model', 'ViT-B-32',
     '--lock-image',
-    '--lock-image-unlocked-groups', '5'
+    '--lock-image-unlocked-groups', '5',
+    '--accum-freq', '2'
     ])
 
 


### PR DESCRIPTION
Should fix #418  

Hi @iejMac @rom1504 @usuyama, It should be the other way around, `output_dict` should be removed because it is passed to `create_model_and_transforms` in main.py, however there was also another small issue while accumulating grads, that should be fixed here.

I tried it and it seems to work ok, however, @iejMac could you maybe try it too and see if training goes as it should?