### PR TITLE
CoCa: Condition captioning loss on the CLIP similarity

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -155,7 +155,7 @@ class CoCaLoss(ClipLoss):
 
         self.clip_loss_weight = clip_loss_weight
         self.caption_loss_weight = caption_loss_weight
-        self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id)
+        self.caption_loss = nn.CrossEntropyLoss(reduction='none', ignore_index=pad_id)
 
     def forward(self, image_features, text_features, logits, labels, logit_scale, output_dict=False):
         clip_loss = super().forward(image_features, text_features, logit_scale)
@@ -165,6 +165,27 @@ class CoCaLoss(ClipLoss):
             logits.permute(0, 2, 1),
             labels,
         )
+
+        # IDEAS:
+        # - do we let gradients prop backward from this? maybe a torch.no_grad is due here
+        # - normalization,
+        # - we want the distribution to be soft so maybe logit scale? !!!
+        # - maybe just softmax is fine since we expect it to be unifrom
+        #   p(good_sammple) >> p(bad_sample)
+        # - TODO: right now posterior = evidence, we need to figure out a smarter
+        #   way of updating our prior which is p(gs) = 1 based on the evidence (CLIP dist)
+        with torch.no_grad():
+            cap_weights = (logit_scale * image_features @ text_features.T).softmax(dim=1).diag().unsqueeze(1)
+            # adjustment = (cap_weights.shape[0] + 1 - cap_weights.sum()) # in the beginning sim ~ U(bs)
+            # cap_weights = cap_weights * adjustment
+
+        # caption_loss = caption_loss * cap_weights.unsqueeze(1)
+        def custom_backward_hook(grad):
+            return cap_weights * grad
+        caption_loss.register_hook(custom_backward_hook)
+
+        caption_loss = torch.mean(caption_loss[caption_loss != 0.0])
+
         caption_loss = caption_loss * self.caption_loss_weight
 
         if output_dict:

--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -179,7 +179,6 @@ class CoCaLoss(ClipLoss):
             # adjustment = (cap_weights.shape[0] + 1 - cap_weights.sum()) # in the beginning sim ~ U(bs)
             # cap_weights = cap_weights * adjustment
 
-        # caption_loss = caption_loss * cap_weights.unsqueeze(1)
         def custom_backward_hook(grad):
             return cap_weights * grad
         caption_loss.register_hook(custom_backward_hook)


### PR DESCRIPTION
This is an attempt at a step in the direction of models determining which samples are relevant for themselves. We can use the CLIP similarities to re-weigh the loss of the captioner. It's kind of like finer filtering.

Some notes:
prior(gs) = 1.0
evidence(gs) = clip similarity over local batch
posterior = ???

currently I just do posterior = evidence but this isn't smart, there is some clever way I just need to think about it more. It's not great during the beginning of training when your CLIP model still sucks because then evidence is just 1/bs always so you effectively just divide your learning rate by batch size. There's some clever thing to do here like the closer you are to the beginning distribution the less you pay attention to CLIP and the more the distribution becomes interesting the more you pay attention to it. Or you can just put it on a schedule like the learning rate.

Wandb: https://wandb.ai/iejmac/open-clip/reports/CLIP-conditioned-caption-loss--VmlldzozODExMzUy