### PR TITLE
--train-num-samples takes priority over guessing the dataset size

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -328,7 +328,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
 
-    num_shards = len(expand_urls(input_shards))
+    num_shards = len(expand_urls(input_shards)[0])
 
     if is_train:
         if args.train_num_samples is not None:

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -337,8 +337,8 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             num_samples = get_num_samples(input_shards)
             if num_samples is None:
                 raise RuntimeError(
-                    'Currently, number of dataset samples must be specified for training dataset. '
-                    'Please specify via `--train-num-samples` if no dataset length info present.')
+                    'Currently, number of dataset samples must be specified for the training dataset. '
+                    'Please specify it via `--train-num-samples` if no dataset length info is present.')
     else:
         # Eval will just exhaust the iterator if the size is not specified.
         num_samples = args.val_num_samples or 0 

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -337,7 +337,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             num_samples = get_num_samples(input_shards)
             if num_samples is None:
                 raise RuntimeError(
-                    'Currently, number of dataset samples must be specified for the training dataset. '
+                    'Currently, the number of dataset samples must be specified for the training dataset. '
                     'Please specify it via `--train-num-samples` if no dataset length info is present.')
     else:
         # Eval will just exhaust the iterator if the size is not specified.

--- a/tests/test_num_shards.py
+++ b/tests/test_num_shards.py
@@ -1,6 +1,6 @@
 import pytest
 
-from training.data import get_dataset_size
+from training.data import expand_urls
 
 @pytest.mark.parametrize(
     "shards,expected_size",
@@ -16,5 +16,5 @@ from training.data import get_dataset_size
     ]
 )
 def test_num_shards(shards, expected_size):
-    _, size = get_dataset_size(shards)
+    size = len(expand_urls(shards)[0])
     assert size == expected_size, f'Expected {expected_size} for {shards} but found {size} instead.'

--- a/tests/test_num_shards.py
+++ b/tests/test_num_shards.py
@@ -1,6 +1,6 @@
 import pytest
 
-from training.data import expand_urls
+from training.data import get_dataset_size
 
 @pytest.mark.parametrize(
     "shards,expected_size",
@@ -16,5 +16,5 @@ from training.data import expand_urls
     ]
 )
 def test_num_shards(shards, expected_size):
-    size = len(expand_urls(shards)[0])
+    _, size = get_dataset_size(shards)
     assert size == expected_size, f'Expected {expected_size} for {shards} but found {size} instead.'


### PR DESCRIPTION
Currently `--train-num-samples` is not used if `get_dataset_size` succeeds in finding the dataset size. This is not ideal because if metadata such as a `sizes.json` file exists, we currently can't control the virtual dataset size. This means we can't have more frequent checkpoints / evaluate more often in case the dataset is big, which is undesirable.

This PR addresses this by giving priority to the `--train-num-samples` flag, only trying to read the metadata files if the flag is not used. 