### PR TITLE
[WIP] Build open_clip as container and publish on push to main

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,87 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+    - main 
+    paths-ignore:
+    - '**.md'
+    - 'CITATION.cff'
+    - 'LICENSE'
+    - '.gitignore'
+    - 'docs/**'
+  pull_request:
+    branches:
+    - main 
+    paths-ignore:
+    - '**.md'
+    - 'CITATION.cff'
+    - 'LICENSE'
+    - '.gitignore'
+    - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      manual_revision_reference:
+        required: false
+        type: string
+      manual_revision_test:
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build & push training Docker image
+        id: build-and-push-training
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.training
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push test Docker image
+        id: build-and-push-test
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-test
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.test
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM python:3.8-slim-buster
+RUN apt-get update && apt-get install -y make
+
+WORKDIR /app
+
+COPY Makefile . 
+COPY requirements-test.txt .
+
+RUN make install-test
+
+COPY . .
+ENTRYPOINT ["python", "-m", "pytest", "-xsv", "tests"]

--- a/Dockerfile.training
+++ b/Dockerfile.training
@@ -1,0 +1,14 @@
+FROM python:3.8-slim-buster
+RUN apt-get update && apt-get install -y make
+
+WORKDIR /app
+
+COPY Makefile . 
+COPY requirements-training.txt .
+
+RUN make install-training
+
+COPY . .
+WORKDIR /app/src/
+
+ENTRYPOINT ["python", "-m", "training.main"]


### PR DESCRIPTION
We (at @marqo-ai) use `open_clip` in a containerised environment. We currently run/use this repository as a container (see @jeadie's [packages](https://github.com/Jeadie/open_clip/pkgs/container/open_clip)). 

I think it'd be good to contribute these back to open_clip and have the image's hosted centrally.

Let me know if you have any questions, or what changes you'd like to see.