### PR TITLE
int8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,14 @@ There are also `m` loss computations instead of the usual 1.
 
 For more information see Cui et al. (https://arxiv.org/abs/2112.09331) or Pham et al. (https://arxiv.org/abs/2111.10050).
 
+### Int8 Support
+
+We have beta support for int8 training and inference.
+You can enable int8 training with `--use-bnb-linear SwitchBackLinearGlobal` or `--use-bnb-linear SwitchBackLinearGlobalMemEfficient`.
+Please see the bitsandbytes library for definitions for these layers.
+For CLIP VIT-Huge this should currently correspond to a 10% training speedup with no accuracy loss.
+More speedups comin when the attention layer is refactored so that linear layers man be replaced there, too.
+
 ### Support for remote loading/training
 
 It is always possible to resume directly from a remote file, e.g., a file in an s3 bucket. Just set `--resume s3://<path-to-checkpoint> `.

--- a/src/open_clip/utils.py
+++ b/src/open_clip/utils.py
@@ -1,6 +1,7 @@
 from itertools import repeat
 import collections.abc
 
+import torch
 from torch import nn as nn
 from torchvision.ops.misc import FrozenBatchNorm2d
 
@@ -58,3 +59,23 @@ to_2tuple = _ntuple(2)
 to_3tuple = _ntuple(3)
 to_4tuple = _ntuple(4)
 to_ntuple = lambda n, x: _ntuple(n)(x)
+
+# Replaces all linear layers with linear_replacement
+def replace_linear(model, linear_replacement, include_modules=['in_proj_linear', 'out_proj', 'c_fc', 'c_proj'], copy_weights=True):
+    for name, module in model.named_children():
+        if len(list(module.children())) > 0:
+            replace_linear(module, linear_replacement, include_modules, copy_weights)
+
+        if isinstance(module, torch.nn.Linear) and name in include_modules:
+            old_module = model._modules[name]
+            model._modules[name] = linear_replacement(
+                module.in_features,
+                module.out_features,
+                module.bias is not None,
+            )
+            if copy_weights:
+                model._modules[name].weight.data.copy_(old_module.weight.data)
+                if model._modules[name].bias is not None:
+                    model._modules[name].bias.data.copy_(old_module.bias)
+
+    return model

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -250,6 +250,7 @@ def main(args):
         print(f'=> replacing linear layers with {args.use_bnb_linear}')
         linear_replacement_cls = getattr(bnb.nn.triton_based_modules, args.use_bnb_linear)
         replace_linear(model, linear_replacement_cls)
+        model = model.to(device)
 
     random_seed(args.seed, args.rank)
 
@@ -287,8 +288,6 @@ def main(args):
         if args.ddp_static_graph:
             # this doesn't exist in older PyTorch, arg only added if enabled
             ddp_args['static_graph'] = True
-        if args.use_bnb_linear is not None:
-            model = model.to(device)
         model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], **ddp_args)
     
         if args.distill:

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -424,6 +424,12 @@ def parse_args(args):
         default=None,
         help='Which pre-trained weights to distill from, if any.'
     )
+    parser.add_argument(
+        "--use-bnb-linear",
+        default=None,
+        help='Replace the network linear layers from the bitsandbytes library. '
+        'Allows int8 training/inference, etc.'
+    )
     args = parser.parse_args(args)
 
     # If some params are not passed, we use the default values based on model name.


### PR DESCRIPTION
This PR introduces beta support for int8 training and inference. You can enable int8 training with `--use-bnb-linear SwitchBackLinearGlobal` or `--use-bnb-linear SwitchBackLinearGlobalMemEfficient`. For CLIP VIT-Huge this should currently correspond to a 10% training speedup with negligable accuracy difference. 

More speedups coming when the attention layer is refactored so that linear layers may be replaced there, too. However, that will require more changes so best to get this merged first.