### PR TITLE
Support serial-worker training

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -418,7 +418,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         batch_size=None,
         shuffle=False,
         num_workers=args.workers,
-        persistent_workers=True,
+        persistent_workers=args.workers > 0,
     )
 
     # FIXME not clear which approach is better, with_epoch before vs after dataloader?


### PR DESCRIPTION
For debugging purposes, sometimes is convenient to use a serial data worker (the number of workers is 0 for the `DataLoader`). For this to work fine, `persistent_workers` needs to be disabled, which is what I change here (conditional to the number of workers value).