### PR TITLE
Implement Locking of Text Tower for `CLIP` Models

### DIFF
--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -205,6 +205,37 @@ class CLIP(nn.Module):
         # lock image tower as per LiT - https://arxiv.org/abs/2111.07991
         self.visual.lock(unlocked_groups=unlocked_groups, freeze_bn_stats=freeze_bn_stats)
 
+    def lock_text_tower(self, unlocked_layers: int = 0, freeze_layer_norm: bool = True):
+        # Unlike the `self.visual` component, the text encoder is embedded into the main class
+        # So we need to do all the work here itself
+        # See `self.encode_text()` for order of ops. We want to freeze the last layers first
+        embeddings = [self.token_embedding, self.positional_embedding]
+        resblocks = self.transformer.resblocks
+        final_text_projection = self.text_projection
+        final_ln = self.ln_final
+
+        # TODO: Make both embeddings behave as one module, and the final_ln + final_text_projection
+        # as a single module as well? Not sure how the final layers are structured in HF
+        modules = [*embeddings, *resblocks, final_text_projection, final_ln]
+
+        if (not unlocked_layers) or (unlocked_layers == 0):  # full freezing
+            modules_to_lock = modules
+        else:
+            modules_to_lock = modules[:-unlocked_layers]
+
+        for module in modules_to_lock:
+            # `self.text_projection` and `self.positional_embedding`
+            if isinstance(module, nn.Parameter):
+                module.requires_grad = False
+
+            # All other modules
+            elif isinstance(module, nn.Module):
+                for n, p in module.named_parameters():
+                    p.requires_grad = (not freeze_layer_norm) if "LayerNorm" in n.split(".") else False
+
+            else:
+                raise TypeError(f"Encountered unexpected module type {type(module)} for module {module}")
+
     @torch.jit.ignore
     def set_grad_checkpointing(self, enable=True):
         self.visual.set_grad_checkpointing(enable)


### PR DESCRIPTION
Currently, the `lock-text.*` args only work when using a `HFTextEncoder`. This PR adds a `lock_text_tower` method to the 'native' `CLIP` class as well.

There's two aspects that are different from the `HFTextEncoder` that I'd love feedback on:
1. `embeddings` in this case are two separate layers, whereas HF has just one
2. `self.text_projection` and `self.ln_final` are passed in as the last two layers respectively. The HF class doesn't have an analogue. So, to unfreeze the last transformer block, you need to pass in `lock-text-unlocked-layers 3`, which feels awkward. 