### PR TITLE
default clip_loss to 0 when self.clip_loss_weight is 0

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -158,8 +158,12 @@ class CoCaLoss(ClipLoss):
         self.caption_loss = nn.CrossEntropyLoss(ignore_index=pad_id)
 
     def forward(self, image_features, text_features, logits, labels, logit_scale, output_dict=False):
-        clip_loss = super().forward(image_features, text_features, logit_scale)
-        clip_loss = self.clip_loss_weight * clip_loss
+        
+        clip_loss = 0
+        
+        if self.clip_loss_weight:
+            clip_loss = super().forward(image_features, text_features, logit_scale)
+            clip_loss = self.clip_loss_weight * clip_loss
 
         caption_loss = self.caption_loss(
             logits.permute(0, 2, 1),


### PR DESCRIPTION
The `CoCaLoss` class currently performs a forward pass to calculate the `clip_loss` regardless of the value of `self.clip_loss_weight`. During CoCa finetuning, `self.clip_loss_weight` is set to 0, yet the forward pass is still executed. I have added a simple "if" statement and default `clip_loss` value to skip the forward pass when `self.clip_loss_weight` is set to 0.