### PR TITLE
CoCaLoss: fix when CLIP weight=0

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -159,7 +159,7 @@ class CoCaLoss(ClipLoss):
 
     def forward(self, image_features, text_features, logits, labels, logit_scale, output_dict=False):
         
-        clip_loss = 0
+        clip_loss = torch.tensor(0.0)
         
         if self.clip_loss_weight:
             clip_loss = super().forward(image_features, text_features, logit_scale)


### PR DESCRIPTION
Fixes this:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/admin/home-iejmac/open_clip_dev/open_clip_iejmac/open_clip/src/training/main.py", line 490, in <module>
    main(sys.argv[1:])
  File "/admin/home-iejmac/open_clip_dev/open_clip_iejmac/open_clip/src/training/main.py", line 418, in main
    train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist_model, args, tb_writer=writer)
  File "/admin/home-iejmac/open_clip_dev/open_clip_iejmac/open_clip/src/training/train.py", line 192, in train_one_epoch
    losses_m[key].update(val.item(), batch_size)
AttributeError: 'int' object has no attribute 'item'
```