### PR TITLE
version pluggy for testing

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 pytest-split==0.8.0
 pytest==7.2.0
+pluggy==1.0.0
 transformers
 timm==0.6.11


### PR DESCRIPTION
@rom1504 @iejMac @rwightman @lopho 

There seemed to be an issue with tests due to a newer release of pluggy, this should be the fix.

I don´t know pytest well enough to be sure so I tagged everybody.

I used the version that was used by CI in the last successful check, current last commit