### PR TITLE
default clip loss

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -159,7 +159,7 @@ class CoCaLoss(ClipLoss):
 
     def forward(self, image_features, text_features, logits, labels, logit_scale, output_dict=False):
         
-        clip_loss = 0
+        clip_loss = torch.tensor(0)
         
         if self.clip_loss_weight:
             clip_loss = super().forward(image_features, text_features, logit_scale)


### PR DESCRIPTION
to avoid computing clip loss when it is zero we still need a tensor otherwise it errors somewhere else.