### PR TITLE
Fix `text.transformer.embeddings.position_ids` key error

### DIFF
--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -225,7 +225,7 @@ def create_model(
 
             if checkpoint_path:
                 logging.info(f'Loading pretrained {model_name} weights ({pretrained}).')
-                load_checkpoint(model, checkpoint_path)
+                load_checkpoint(model, checkpoint_path, strict=False)
             else:
                 error_str = (
                     f'Pretrained weights ({pretrained}) not found for model {model_name}.'
@@ -235,7 +235,7 @@ def create_model(
             pretrained_loaded = True
         elif has_hf_hub_prefix:
             logging.info(f'Loading pretrained {model_name} weights ({pretrained}).')
-            load_checkpoint(model, checkpoint_path)
+            load_checkpoint(model, checkpoint_path, strict=False)
             pretrained_loaded = True
 
         if require_pretrained and not pretrained_loaded:

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -100,6 +100,10 @@ def load_checkpoint(model, checkpoint_path, strict=True):
     # detect old format and make compatible with new format
     if 'positional_embedding' in state_dict and not hasattr(model, 'positional_embedding'):
         state_dict = convert_to_custom_text_state_dict(state_dict)
+    # Certain text transformers no longer expect position_ids after transformers==4.31
+    position_id_key = 'text.transformer.embeddings.position_ids'
+    if position_id_key in state_dict and not hasattr(model, position_id_key):
+        del state_dict[position_id_key]
     resize_pos_embed(state_dict, model)
     incompatible_keys = model.load_state_dict(state_dict, strict=strict)
     return incompatible_keys
@@ -225,7 +229,7 @@ def create_model(
 
             if checkpoint_path:
                 logging.info(f'Loading pretrained {model_name} weights ({pretrained}).')
-                load_checkpoint(model, checkpoint_path, strict=False)
+                load_checkpoint(model, checkpoint_path)
             else:
                 error_str = (
                     f'Pretrained weights ({pretrained}) not found for model {model_name}.'
@@ -235,7 +239,7 @@ def create_model(
             pretrained_loaded = True
         elif has_hf_hub_prefix:
             logging.info(f'Loading pretrained {model_name} weights ({pretrained}).')
-            load_checkpoint(model, checkpoint_path, strict=False)
+            load_checkpoint(model, checkpoint_path)
             pretrained_loaded = True
 
         if require_pretrained and not pretrained_loaded:


### PR DESCRIPTION
This PR is to fix https://github.com/mlfoundations/open_clip/discussions/584.

After `transformers==4.31`, certain text transformers no longer expect `text.transformer.embeddings.position_ids` (https://github.com/huggingface/transformers/pull/24505). The recommendation is to use `from_pretrained` (https://github.com/huggingface/transformers/issues/25330#issuecomment-1667235015) but that's not an option for loading a module. So, I just explicitly identify this inconsistency and edit `state_dict` if necessary. Tested with both `transformers==4.30.2` and `transformers==4.31`.