### PR TITLE
Integrate Updates to BeamSearchScorer

### DIFF
--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -320,10 +320,10 @@ class CoCa(nn.Module):
             else logit_processor
         )
 
-        batch_size = len(beam_scorer._beam_hyps)
         num_beams = beam_scorer.num_beams
         num_beam_groups = beam_scorer.num_beam_groups
         num_sub_beams = num_beams // num_beam_groups
+        batch_size = len(beam_scorer._beam_hyps) // num_beam_groups
         batch_beam_size, cur_len = input_ids.shape
         beam_indices = None
 
@@ -400,6 +400,7 @@ class CoCa(nn.Module):
                     pad_token_id=pad_token_id,
                     eos_token_id=eos_token_id,
                     beam_indices=process_beam_indices,
+                    group_index=beam_group_idx,
                 )
                 beam_scores[batch_group_indices] = beam_outputs["next_beam_scores"]
                 beam_next_tokens = beam_outputs["next_beam_tokens"]


### PR DESCRIPTION
CoCa `generate()` fails on `transformers>=4.31.0` due to [fixes](https://github.com/huggingface/transformers/commit/43479ef98f2d9f1600793922cf022d7d0670a5f8)  in `BeamSearchScorer`. 

Specifically, the following snippet:
```
model, _, transform = open_clip.create_model_and_transforms(
  model_name="coca_ViT-L-14",
  pretrained="mscoco_finetuned_laion2B-s13B-b90k"
)
PIL_image = Image.open(im_path).convert("RGB")

im = transform(PIL_image).unsqueeze(0)
with torch.no_grad(), torch.cuda.amp.autocast():
  generated = model.generate(im)
```
results in:
```
in _generate_beamsearch(self, image_inputs, pad_token_id, eos_token_id, sot_token_id, num_beams, num_beam_groups, min_seq_len, stopping_criteria, logit_processor, logit_warper)
    329 
    330         if num_beams * batch_size != batch_beam_size:
--> 331             raise ValueError(
    332                 f"Batch dimension of `input_ids` should be {num_beams * batch_size}, but is {batch_beam_size}."
    333             )

ValueError: Batch dimension of `input_ids` should be 18, but is 6.
```

This PR just ports over their changes in generation utils.