### PR TITLE
Fixed padding error in ResizeMaxSize

### DIFF
--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -40,9 +40,10 @@ class ResizeMaxSize(nn.Module):
         else:
             width, height = img.size
         scale = self.max_size / float(max(height, width))
+        new_size = tuple(round(dim * scale) for dim in (height, width))
         if scale != 1.0:
-            new_size = tuple(round(dim * scale) for dim in (height, width))
             img = F.resize(img, new_size, self.interpolation)
+        if not width == height:
             pad_h = self.max_size - new_size[0]
             pad_w = self.max_size - new_size[1]
             img = F.pad(img, padding=[pad_w//2, pad_h//2, pad_w - pad_w//2, pad_h - pad_h//2], fill=self.fill)


### PR DESCRIPTION
This fixes the error described in issue #629 when no padding in 
 ResizeMaxSize is performed if `width or `height` are the same as `max_size`.