### PR TITLE
Update default # workers from 1 -> 4

### DIFF
--- a/src/training/params.py
+++ b/src/training/params.py
@@ -120,7 +120,7 @@ def parse_args(args):
         help="Optional identifier for the experiment when storing logs. Otherwise use current time.",
     )
     parser.add_argument(
-        "--workers", type=int, default=1, help="Number of dataloader workers per GPU."
+        "--workers", type=int, default=4, help="Number of dataloader workers per GPU."
     )
     parser.add_argument(
         "--batch-size", type=int, default=64, help="Batch size per GPU."


### PR DESCRIPTION
Default workers of 1 results in incredibly slow dataloading if someone didn't remember to change the setting. 4 is a more reasonable value without being too large as to cause concerns with smaller datasets or oversubscribed CPUs.