### PR TITLE
use MPS and explicitly disable autocast & GradScaler for non-CUDA

### DIFF
--- a/src/training/distributed.py
+++ b/src/training/distributed.py
@@ -107,6 +107,8 @@ def init_distributed_device(args):
         else:
             device = 'cuda:0'
         torch.cuda.set_device(device)
+    elif torch.backends.mps.is_available():
+        device = "mps"
     else:
         device = 'cpu'
     args.device = device

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -326,7 +326,8 @@ def main(args):
             hvd.broadcast_parameters(model.state_dict(), root_rank=0)
             hvd.broadcast_optimizer_state(optimizer, root_rank=0)
 
-        scaler = GradScaler() if args.precision == "amp" else None
+        if args.precision == "amp" and args.device.startswith("cuda"):
+            scaler = GradScaler()
 
     # optionally resume from a checkpoint
     start_epoch = 0

--- a/src/training/precision.py
+++ b/src/training/precision.py
@@ -4,21 +4,21 @@ import logging
 import torch
 
 def get_autocast(precision, device='cuda'):
-    if device == 'mps':
-        logging.warning(
-            "MPS devices do not support AMP yet: "
-            "https://github.com/pytorch/pytorch/issues/88415 "
-            "Disabling AMP and falling back to FP32."
-        )
-        return suppress
-    elif device == 'cpu':
-        logging.warning(
-            "CPU devices have limited AMP support and result in "
-            "attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. "
-            "Disabling AMP and falling back to FP32."
-        )
-        return suppress
-
+    if precision.startswith('amp'):
+        if device == 'mps':
+            logging.warning(
+                "MPS devices do not support AMP yet: "
+                "https://github.com/pytorch/pytorch/issues/88415 "
+                "Disabling AMP and falling back to FP32."
+            )
+            return suppress
+        elif device == 'cpu':
+            logging.warning(
+                "CPU devices have limited AMP support and result in "
+                "attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. "
+                "Disabling AMP and falling back to FP32."
+            )
+            return suppress
     if precision == 'amp':
         return torch.cuda.amp.autocast
     elif precision == 'amp_bfloat16' or precision == 'amp_bf16':

--- a/src/training/precision.py
+++ b/src/training/precision.py
@@ -1,8 +1,24 @@
-import torch
 from contextlib import suppress
+import logging
 
+import torch
 
-def get_autocast(precision):
+def get_autocast(precision, device='cuda'):
+    if device == 'mps':
+        logging.warning(
+            "MPS devices do not support AMP yet: "
+            "https://github.com/pytorch/pytorch/issues/88415 "
+            "Disabling AMP and falling back to FP32."
+        )
+        return suppress
+    elif device == 'cpu':
+        logging.warning(
+            "CPU devices have limited AMP support and result in "
+            "attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. "
+            "Disabling AMP and falling back to FP32."
+        )
+        return suppress
+
     if precision == 'amp':
         return torch.cuda.amp.autocast
     elif precision == 'amp_bfloat16' or precision == 'amp_bf16':

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -63,7 +63,7 @@ def backward(total_loss, scaler):
 
 def train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist_model, args, tb_writer=None):
     device = torch.device(args.device)
-    autocast = get_autocast(args.precision)
+    autocast = get_autocast(args.precision, device=args.device)
     input_dtype = get_input_dtype(args.precision)
 
     model.train()
@@ -255,7 +255,7 @@ def evaluate(model, data, epoch, args, tb_writer=None):
     zero_shot_metrics = zero_shot_eval(model, data, epoch, args)
     metrics.update(zero_shot_metrics)
 
-    autocast = get_autocast(args.precision)
+    autocast = get_autocast(args.precision, device=args.device)
     input_dtype = get_input_dtype(args.precision)
 
     if 'val' in data and (args.val_frequency and ((epoch % args.val_frequency) == 0 or epoch == args.epochs)):

--- a/src/training/zero_shot.py
+++ b/src/training/zero_shot.py
@@ -16,7 +16,7 @@ def accuracy(output, target, topk=(1,)):
 
 
 def run(model, classifier, dataloader, args):
-    autocast = get_autocast(args.precision)
+    autocast = get_autocast(args.precision, device=args.device)
     input_dtype = get_input_dtype(args.precision)
 
     with torch.no_grad():
@@ -55,7 +55,7 @@ def zero_shot_eval(model, data, epoch, args):
     logging.info('Starting zero-shot imagenet.')
 
     logging.info('Building zero-shot classifier')
-    autocast = get_autocast(args.precision)
+    autocast = get_autocast(args.precision, device=args.device)
     with autocast():
         tokenizer = get_tokenizer(args.model)
         classifier = build_zero_shot_classifier(


### PR DESCRIPTION
`device = "mps"` makes both training and inference ~ an order of magnitude faster on newer Macs, `torch==2.2.0.dev20231002`:

Training: [MPS vs. CPU](https://api.wandb.ai/links/eify/y7r3yzwb), RN50 model (username redacted)
```
python3 -m training.main \
    --report-to wandb \
    --name MPS-batch-512 \
    --save-frequency 1 \
    --train-data="/Users/█/Downloads/redcaps_v1.0_annotations/tarfiles/redcaps_combined_{00000000..00000585}.tar" \
    --train-num-samples 585668 \
    --dataset-type webdataset \
    --warmup 1000 \
    --batch-size=512 \
    --lr=5e-4 \
    --wd=0.1 \
    --epochs=5 \
    --workers=0 \
    --model RN50
```
<img width="373" alt="Screenshot 2023-10-04 at 1 35 32 PM" src="https://github.com/mlfoundations/open_clip/assets/2584418/b698756d-9c80-4f87-b40d-ccd4ddc7991a">

Inference:
```

time python3 -m training.main \
    --imagenet-val="/Users/█/Downloads/ImageNetV2-val/" \
    --model RN50 \
    --pretrained logs/MPS-batch-512/checkpoints/epoch_5.pt \

mps:

2023-10-04,13:00:17 | INFO | Starting zero-shot imagenet.
2023-10-04,13:00:17 | INFO | Building zero-shot classifier
2023-10-04,13:00:17 | WARNING | MPS devices do not support AMP yet: https://github.com/pytorch/pytorch/issues/88415 Disabling AMP and falling back to FP32.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [03:19<00:00,  5.03it/s]
2023-10-04,13:03:36 | INFO | Using classifier
2023-10-04,13:03:36 | WARNING | MPS devices do not support AMP yet: https://github.com/pytorch/pytorch/issues/88415 Disabling AMP and falling back to FP32.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50048/50048 [02:46<00:00, 300.65it/s]
2023-10-04,13:06:23 | INFO | Finished zero-shot imagenet.
2023-10-04,13:06:23 | WARNING | MPS devices do not support AMP yet: https://github.com/pytorch/pytorch/issues/88415 Disabling AMP and falling back to FP32.
2023-10-04,13:06:23 | INFO | Eval Epoch: 0 imagenet-zeroshot-val-top1: 0.0282   imagenet-zeroshot-val-top5: 0.0905
[2023-10-04 13:06:23,130] torch._dynamo.utils: [INFO] TorchDynamo compilation metrics:
[2023-10-04 13:06:23,130] torch._dynamo.utils: [INFO] Function, Runtimes (s)

real    6m12.258s
user    4m51.843s
sys 0m49.552s

cpu:

2023-10-04,11:28:18 | INFO | Starting zero-shot imagenet.
2023-10-04,11:28:18 | INFO | Building zero-shot classifier
2023-10-04,11:28:18 | WARNING | CPU devices have limited AMP support and result in attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. Disabling AMP and falling back to FP32.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [09:33<00:00,  1.75it/s]
2023-10-04,11:37:51 | INFO | Using classifier
2023-10-04,11:37:51 | WARNING | CPU devices have limited AMP support and result in attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. Disabling AMP and falling back to FP32.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50048/50048 [1:06:30<00:00, 12.54it/s]
2023-10-04,12:44:21 | INFO | Finished zero-shot imagenet.
2023-10-04,12:44:21 | WARNING | CPU devices have limited AMP support and result in attn_mask.dtype: float and query.dtype: c10::BFloat16 mismatch. Disabling AMP and falling back to FP32.
2023-10-04,12:44:21 | INFO | Eval Epoch: 0 imagenet-zeroshot-val-top1: 0.0282   imagenet-zeroshot-val-top5: 0.0905
[2023-10-04 12:44:21,412] torch._dynamo.utils: [INFO] TorchDynamo compilation metrics:
[2023-10-04 12:44:21,412] torch._dynamo.utils: [INFO] Function, Runtimes (s)

real    76m8.598s
user    396m31.792s
sys 35m38.153s
```
This PR also includes explicit handling of autocast & GradScaler for non-CUDA devices. Currently open_clip is hardcoded to use the CUDA version (`torch.cuda.amp.autocast` and `torch.cuda.amp.GradScaler` respectively), which get disabled with warnings like
```
/Users/█/Library/Python/3.10/lib/python/site-packages/torch/amp/autocast_mode.py:250: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
```
```
/Users/█/Library/Python/3.10/lib/python/site-packages/torch/cuda/amp/grad_scaler.py:124: UserWarning: torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling.
  warnings.warn(
```
With this PR we issue our own warnings and explain the rationales & consequences:
1. AMP support for MPS devices is tracked  with https://github.com/pytorch/pytorch/issues/88415
2. We do have [`torch.cpu.amp.autocast`](https://pytorch.org/docs/stable/amp.html#torch.cpu.amp.autocast) but training with it failed with the stated attn_mask & query dtype mismatch.