### PR TITLE
remove version limit for protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ ftfy
 tqdm
 huggingface_hub
 sentencepiece
-protobuf<4
+protobuf
 timm


### PR DESCRIPTION
Remove the version limit for protobuf since it's no longer needed. The version limit was added because of this issue #246 but that has been resolved in the transformers library with [this](https://github.com/huggingface/transformers/pull/24599) pull request and [commit](https://github.com/huggingface/transformers/commit/299aafe55ff03c565c059682c6fd312e4b89bc2f).

Fixes #623 