### PR TITLE
use bool masks

### DIFF
--- a/src/open_clip/transformer.py
+++ b/src/open_clip/transformer.py
@@ -586,7 +586,7 @@ class TextTransformer(nn.Module):
 
     def build_cls_mask(self, text, cast_dtype: torch.dtype):
         cls_mask = (text != self.pad_id).unsqueeze(1)
-        cls_mask = F.pad(cls_mask, (1, 0, cls_mask.shape[2], 0), value=1.0)
+        cls_mask = F.pad(cls_mask, (1, 0, cls_mask.shape[2], 0), value=True)
         additive_mask = torch.empty(cls_mask.shape, dtype=cast_dtype, device=cls_mask.device)
         additive_mask.fill_(0)
         additive_mask.masked_fill_(~cls_mask, float("-inf"))

--- a/tests/test_hf_model.py
+++ b/tests/test_hf_model.py
@@ -8,8 +8,8 @@ from transformers.modeling_outputs import BaseModelOutput
 def test_poolers():
     bs, sl, d = 2, 10, 5
     h = torch.arange(sl).repeat(bs).reshape(bs, sl)[..., None] * torch.linspace(0.2, 1., d)
-    mask = torch.ones(bs, sl, dtype=torch.long)
-    mask[:2, 6:] = 0
+    mask = torch.ones(bs, sl, dtype=torch.bool)
+    mask[:2, 6:] = False
     x = BaseModelOutput(h)
     for name, cls in _POOLERS.items():
         pooler = cls()


### PR DESCRIPTION
[PyTorch 2.1](https://github.com/pytorch/pytorch/releases/tag/v2.1.0) is disallowing non-bool masks in the `masked_fill` and `masked_fill_`. This pull request fixed the tests failing because of this change.