### PR TITLE
Fix `random_mask_tokenize` when the text is long

### DIFF
--- a/src/open_clip/tokenizer.py
+++ b/src/open_clip/tokenizer.py
@@ -250,7 +250,7 @@ def random_mask_tokenize(texts: Union[str, List[str]], context_length: int = 77)
         if len(tokens) > context_length - 2: # 2 for sot and eot token
             indices = np.random.permutation(len(tokens)).tolist()
             indices = indices[:context_length - 2]
-            tokens = tokens[indices]
+            tokens = [tokens[i] for i in indices]
         tokens = [sot_token,] + tokens + [eot_token,]
         result[i, :len(tokens)] = torch.tensor(tokens)
 


### PR DESCRIPTION
Without this patch, the function crashes for long texts. See https://colab.research.google.com/drive/1SHBAUEnI1dNJmXQPUqZekFqXm7xrwH65?usp=sharing