### PR TITLE
move tok spacing from config to model init

### DIFF
--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -23,21 +23,17 @@ try:
         RepetitionPenaltyLogitsProcessor,
         MinLengthLogitsProcessor,
         MaxLengthCriteria,
-        StoppingCriteriaList
+        StoppingCriteriaList,
     )
 
     GENERATION_TYPES = {
         "top_k": TopKLogitsWarper,
         "top_p": TopPLogitsWarper,
-        "beam_search": "beam_search"
+        "beam_search": "beam_search",
     }
     _has_transformers = True
 except ImportError as e:
-    GENERATION_TYPES = {
-        "top_k": None,
-        "top_p": None,
-        "beam_search": "beam_search"
-    }
+    GENERATION_TYPES = {"top_k": None, "top_p": None, "beam_search": "beam_search"}
     _has_transformers = False
 
 
@@ -51,16 +47,16 @@ class MultimodalCfg(CLIPTextCfg):
 
 
 def _build_text_decoder_tower(
-        embed_dim,
-        multimodal_cfg,
-        quick_gelu: bool = False,
-        cast_dtype: Optional[torch.dtype] = None,
+    embed_dim,
+    multimodal_cfg,
+    quick_gelu: bool = False,
+    cast_dtype: Optional[torch.dtype] = None,
 ):
-    multimodal_cfg = MultimodalCfg(**multimodal_cfg) if isinstance(multimodal_cfg, dict) else multimodal_cfg
-    act_layer = QuickGELU if quick_gelu else nn.GELU
-    norm_layer = (
-        LayerNormFp32 if cast_dtype in (torch.float16, torch.bfloat16) else LayerNorm
+    multimodal_cfg = (
+        MultimodalCfg(**multimodal_cfg) if isinstance(multimodal_cfg, dict) else multimodal_cfg
     )
+    act_layer = QuickGELU if quick_gelu else nn.GELU
+    norm_layer = LayerNormFp32 if cast_dtype in (torch.float16, torch.bfloat16) else LayerNorm
 
     decoder = MultimodalTransformer(
         context_length=multimodal_cfg.context_length,
@@ -78,19 +74,23 @@ def _build_text_decoder_tower(
 
 class CoCa(nn.Module):
     def __init__(
-            self,
-            embed_dim,
-            multimodal_cfg: MultimodalCfg,
-            text_cfg: CLIPTextCfg,
-            vision_cfg: CLIPVisionCfg,
-            quick_gelu: bool = False,
-            cast_dtype: Optional[torch.dtype] = None,
-            pad_id: int = 0,
+        self,
+        embed_dim,
+        multimodal_cfg: MultimodalCfg,
+        text_cfg: CLIPTextCfg,
+        vision_cfg: CLIPVisionCfg,
+        quick_gelu: bool = False,
+        cast_dtype: Optional[torch.dtype] = None,
+        pad_id: int = 0,
     ):
         super().__init__()
-        multimodal_cfg = MultimodalCfg(**multimodal_cfg) if isinstance(multimodal_cfg, dict) else multimodal_cfg
+        multimodal_cfg = (
+            MultimodalCfg(**multimodal_cfg) if isinstance(multimodal_cfg, dict) else multimodal_cfg
+        )
         text_cfg = CLIPTextCfg(**text_cfg) if isinstance(text_cfg, dict) else text_cfg
         vision_cfg = CLIPVisionCfg(**vision_cfg) if isinstance(vision_cfg, dict) else vision_cfg
+
+        text_cfg.vocab_size -= 1  # make space for CLS token
 
         self.text = _build_text_tower(
             embed_dim=embed_dim,
@@ -134,7 +134,7 @@ class CoCa(nn.Module):
         return image_latent, tokens_embs
 
     def _encode_text(self, text, normalize: bool = True, embed_cls: bool = True):
-        text = text[:, :-1] if embed_cls else text # make space for CLS token
+        text = text[:, :-1] if embed_cls else text  # make space for CLS token
         text_latent, token_emb = self.text(text)
         text_latent = F.normalize(text_latent, dim=-1) if normalize else text_latent
         return text_latent, token_emb
@@ -148,12 +148,12 @@ class CoCa(nn.Module):
         return text_latent
 
     def forward(
-            self,
-            image,
-            text: Optional[torch.Tensor] = None,
-            embed_cls: bool = True,
-            image_latent: Optional[torch.Tensor] = None,
-            image_embs: Optional[torch.Tensor] = None,
+        self,
+        image,
+        text: Optional[torch.Tensor] = None,
+        embed_cls: bool = True,
+        image_latent: Optional[torch.Tensor] = None,
+        image_embs: Optional[torch.Tensor] = None,
     ):
         if image_latent is None or image_embs is None:
             image_latent, image_embs = self._encode_image(image)
@@ -164,7 +164,7 @@ class CoCa(nn.Module):
         text_latent, token_embs = self._encode_text(text, embed_cls=embed_cls)
 
         # TODO: add assertion to avoid bugs?
-        labels = text[:, -token_embs.shape[1]:]
+        labels = text[:, -token_embs.shape[1] :]
 
         logits = self.text_decoder(image_embs, token_embs)
         return {
@@ -172,7 +172,7 @@ class CoCa(nn.Module):
             "text_features": text_latent,
             "logits": logits,
             "labels": labels,
-            "logit_scale": self.logit_scale.exp()
+            "logit_scale": self.logit_scale.exp(),
         }
 
     def generate(
@@ -181,7 +181,7 @@ class CoCa(nn.Module):
         text=None,
         seq_len=30,
         max_seq_len=77,
-        temperature=1.,
+        temperature=1.0,
         generation_type="beam_search",
         top_p=0.1,  # keep tokens in the 1 - top_p quantile
         top_k=1,  # keeps the top_k most probable tokens
@@ -193,11 +193,13 @@ class CoCa(nn.Module):
         min_seq_len=5,
         stopping_criteria=None,
         repetition_penalty=1.0,
-        fixed_output_length=False # if True output.shape == (batch_size, seq_len)
+        fixed_output_length=False,  # if True output.shape == (batch_size, seq_len)
     ):
         # taking many ideas and components from HuggingFace GenerationMixin
         # https://huggingface.co/docs/transformers/main/en/main_classes/text_generation
-        assert _has_transformers, "Please install transformers for generate functionality. `pip install transformers`."
+        assert (
+            _has_transformers
+        ), "Please install transformers for generate functionality. `pip install transformers`."
         assert seq_len > min_seq_len, "seq_len must be larger than min_seq_len"
 
         with torch.no_grad():
@@ -214,15 +216,13 @@ class CoCa(nn.Module):
             if stopping_criteria is None:
                 stopping_criteria = [MaxLengthCriteria(max_length=seq_len)]
 
-            stopping_criteria = StoppingCriteriaList(
-                stopping_criteria
-            )
+            stopping_criteria = StoppingCriteriaList(stopping_criteria)
 
             device = image.device
 
             if generation_type == "beam_search":
                 output = self._generate_beamsearch(
-                    image_inputs = image,
+                    image_inputs=image,
                     pad_token_id=pad_token_id,
                     eos_token_id=eos_token_id,
                     sot_token_id=sot_token_id,
@@ -234,8 +234,17 @@ class CoCa(nn.Module):
                 )
                 if fixed_output_length and output.shape[1] < seq_len:
                     return torch.cat(
-                        (output, torch.ones(output.shape[0], seq_len-output.shape[1], device=device, dtype=output.dtype) * self.pad_id),
-                        dim=1
+                        (
+                            output,
+                            torch.ones(
+                                output.shape[0],
+                                seq_len - output.shape[1],
+                                device=device,
+                                dtype=output.dtype,
+                            )
+                            * self.pad_id,
+                        ),
+                        dim=1,
                     )
                 return output
 
@@ -252,7 +261,9 @@ class CoCa(nn.Module):
             image_latent, image_embs = self._encode_image(image)
 
             if text is None:
-                text = torch.ones((image.shape[0], 1), device=device, dtype=torch.long) * sot_token_id
+                text = (
+                    torch.ones((image.shape[0], 1), device=device, dtype=torch.long) * sot_token_id
+                )
 
             was_training = self.training
             num_dims = len(text.shape)
@@ -267,9 +278,13 @@ class CoCa(nn.Module):
             while True:
                 x = out[:, -max_seq_len:]
                 cur_len = x.shape[1]
-                logits = self(image, x, image_latent=image_latent, image_embs=image_embs, embed_cls=False)["logits"][:, -1]
+                logits = self(
+                    image, x, image_latent=image_latent, image_embs=image_embs, embed_cls=False
+                )["logits"][:, -1]
                 mask = (out[:, -1] == eos_token_id) | (out[:, -1] == pad_token_id)
-                sample = torch.ones((out.shape[0], 1), device=device, dtype=torch.long) * pad_token_id
+                sample = (
+                    torch.ones((out.shape[0], 1), device=device, dtype=torch.long) * pad_token_id
+                )
 
                 if mask.all():
                     if not fixed_output_length:
@@ -280,8 +295,11 @@ class CoCa(nn.Module):
                     filtered_logits = logit_warper(x[~mask, :], filtered_logits)
                     probs = F.softmax(filtered_logits / temperature, dim=-1)
 
-                    if (cur_len + 1 == seq_len):
-                        sample[~mask, :] = torch.ones((sum(~mask), 1), device=device, dtype=torch.long) * eos_token_id
+                    if cur_len + 1 == seq_len:
+                        sample[~mask, :] = (
+                            torch.ones((sum(~mask), 1), device=device, dtype=torch.long)
+                            * eos_token_id
+                        )
                     else:
                         sample[~mask, :] = torch.multinomial(probs, 1)
 
@@ -299,17 +317,17 @@ class CoCa(nn.Module):
             return out
 
     def _generate_beamsearch(
-            self,
-            image_inputs,
-            pad_token_id=None,
-            eos_token_id=None,
-            sot_token_id=None,
-            num_beams=6,
-            num_beam_groups=3,
-            min_seq_len=5,
-            stopping_criteria=None,
-            logit_processor=None,
-            logit_warper=None,
+        self,
+        image_inputs,
+        pad_token_id=None,
+        eos_token_id=None,
+        sot_token_id=None,
+        num_beams=6,
+        num_beam_groups=3,
+        min_seq_len=5,
+        stopping_criteria=None,
+        logit_processor=None,
+        logit_warper=None,
     ):
         device = image_inputs.device
         batch_size = image_inputs.shape[0]
@@ -350,21 +368,26 @@ class CoCa(nn.Module):
         beam_scores = beam_scores.view((batch_size * num_beams,))
 
         while True:
-
             # predicted tokens in cur_len step
-            current_tokens = torch.zeros(batch_size * num_beams, dtype=input_ids.dtype, device=device)
+            current_tokens = torch.zeros(
+                batch_size * num_beams, dtype=input_ids.dtype, device=device
+            )
 
             # indices which will form the beams in the next time step
-            reordering_indices = torch.zeros(batch_size * num_beams, dtype=torch.long, device=device)
+            reordering_indices = torch.zeros(
+                batch_size * num_beams, dtype=torch.long, device=device
+            )
 
             # do one decoder step on all beams of all sentences in batch
-            model_inputs = prepare_inputs_for_generation(input_ids=input_ids, image_inputs=image_inputs)
+            model_inputs = prepare_inputs_for_generation(
+                input_ids=input_ids, image_inputs=image_inputs
+            )
             outputs = self(
-                model_inputs['images'],
-                model_inputs['text'],
+                model_inputs["images"],
+                model_inputs["text"],
                 embed_cls=False,
                 image_latent=image_latent,
-                image_embs=image_embs
+                image_embs=image_embs,
             )
 
             for beam_group_idx in range(num_beam_groups):
@@ -377,18 +400,26 @@ class CoCa(nn.Module):
 
                 for batch_idx in range(batch_size):
                     batch_group_indices.extend(
-                        [batch_idx * num_beams + idx for idx in range(group_start_idx, group_end_idx)]
+                        [
+                            batch_idx * num_beams + idx
+                            for idx in range(group_start_idx, group_end_idx)
+                        ]
                     )
                 group_input_ids = input_ids[batch_group_indices]
 
                 # select outputs of beams of currentg group only
-                next_token_logits = outputs['logits'][batch_group_indices, -1, :]
+                next_token_logits = outputs["logits"][batch_group_indices, -1, :]
                 vocab_size = next_token_logits.shape[-1]
 
                 next_token_scores_processed = logits_processor(
-                    group_input_ids, next_token_logits, current_tokens=current_tokens, beam_group_idx=beam_group_idx
+                    group_input_ids,
+                    next_token_logits,
+                    current_tokens=current_tokens,
+                    beam_group_idx=beam_group_idx,
                 )
-                next_token_scores = next_token_scores_processed + beam_scores[batch_group_indices].unsqueeze(-1)
+                next_token_scores = next_token_scores_processed + beam_scores[
+                    batch_group_indices
+                ].unsqueeze(-1)
                 next_token_scores = next_token_scores.expand_as(next_token_scores_processed)
 
                 # reshape for beam search
@@ -418,13 +449,17 @@ class CoCa(nn.Module):
                 beam_idx = beam_outputs["next_beam_indices"]
 
                 input_ids[batch_group_indices] = group_input_ids[beam_idx]
-                group_input_ids = torch.cat([group_input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
+                group_input_ids = torch.cat(
+                    [group_input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1
+                )
                 current_tokens[batch_group_indices] = group_input_ids[:, -1]
 
                 # (beam_idx // group_size) -> batch_idx
                 # (beam_idx % group_size) -> offset of idx inside the group
                 reordering_indices[batch_group_indices] = (
-                    num_beams * torch.div(beam_idx, group_size, rounding_mode="floor") + group_start_idx + (beam_idx % group_size)
+                    num_beams * torch.div(beam_idx, group_size, rounding_mode="floor")
+                    + group_start_idx
+                    + (beam_idx % group_size)
                 )
 
             input_ids = torch.cat([input_ids, current_tokens.unsqueeze(-1)], dim=-1)
@@ -445,7 +480,7 @@ class CoCa(nn.Module):
             max_length=stopping_criteria.max_length,
             beam_indices=final_beam_indices,
         )
-        return sequence_outputs['sequences']
+        return sequence_outputs["sequences"]
 
 
 def prepare_inputs_for_generation(input_ids, image_inputs, past=None, **kwargs):

--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -90,7 +90,7 @@ class CoCa(nn.Module):
         text_cfg = CLIPTextCfg(**text_cfg) if isinstance(text_cfg, dict) else text_cfg
         vision_cfg = CLIPVisionCfg(**vision_cfg) if isinstance(vision_cfg, dict) else vision_cfg
 
-        text_cfg.vocab_size -= 1  # make space for CLS token
+        text_cfg.context_length -= 1  # make space for CLS token
 
         self.text = _build_text_tower(
             embed_dim=embed_dim,

--- a/src/open_clip/model_configs/coca_ViT-B-32.json
+++ b/src/open_clip/model_configs/coca_ViT-B-32.json
@@ -10,7 +10,7 @@
         "output_tokens": true
     },
     "text_cfg": {
-        "context_length": 76,
+        "context_length": 77,
         "vocab_size": 49408,
         "width": 512,
         "heads": 8,

--- a/src/open_clip/model_configs/coca_ViT-L-14.json
+++ b/src/open_clip/model_configs/coca_ViT-L-14.json
@@ -10,7 +10,7 @@
         "output_tokens": true
     },
     "text_cfg": {
-        "context_length": 76,
+        "context_length": 77,
         "vocab_size": 49408,
         "width": 768,
         "heads": 12,

--- a/src/open_clip/model_configs/coca_base.json
+++ b/src/open_clip/model_configs/coca_base.json
@@ -19,7 +19,7 @@
         "output_tokens": true
     },
     "text_cfg": {
-        "context_length": 76,
+        "context_length": 77,
         "vocab_size": 64000,
         "layers": 12,
         "heads": 12,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,13 +1,12 @@
-
 import os
 import pytest
 import torch
 import open_clip
 import util_test
 
-os.environ['CUDA_VISIBLE_DEVICES'] = ''
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
-if hasattr(torch._C, '_jit_set_profiling_executor'):
+if hasattr(torch._C, "_jit_set_profiling_executor"):
     # legacy executor is too slow to compile large models for unit tests
     # no need for the fusion performance here
     torch._C._jit_set_profiling_executor(True)
@@ -16,25 +15,26 @@ if hasattr(torch._C, '_jit_set_profiling_executor'):
 models_to_test = set(open_clip.list_models())
 
 # testing excemptions
-models_to_test = models_to_test.difference({
+models_to_test = models_to_test.difference(
+    {
         # not available with timm yet
         # see https://github.com/mlfoundations/open_clip/issues/219
-        'convnext_xlarge',
-        'convnext_xxlarge',
-        'convnext_xxlarge_320',
-        'vit_medium_patch16_gap_256',
+        "convnext_xlarge",
+        "convnext_xxlarge",
+        "convnext_xxlarge_320",
+        "vit_medium_patch16_gap_256",
         # exceeds GH runner memory limit
-        'ViT-bigG-14',
-        'ViT-e-14',
-        'mt5-xl-ViT-H-14',
-        'coca_base',
-        'coca_ViT-B-32',
-        'coca_roberta-ViT-B-32'
-})
+        "ViT-bigG-14",
+        "ViT-e-14",
+        "mt5-xl-ViT-H-14",
+        "coca_base",
+        "coca_roberta-ViT-B-32",
+    }
+)
 
-if 'OPEN_CLIP_TEST_REG_MODELS' in os.environ:
-    external_model_list = os.environ['OPEN_CLIP_TEST_REG_MODELS']
-    with open(external_model_list, 'r') as f:
+if "OPEN_CLIP_TEST_REG_MODELS" in os.environ:
+    external_model_list = os.environ["OPEN_CLIP_TEST_REG_MODELS"]
+    with open(external_model_list, "r") as f:
         models_to_test = set(f.read().splitlines()).intersection(models_to_test)
     print(f"Selected models from {external_model_list}: {models_to_test}")
 
@@ -52,31 +52,31 @@ models_to_test_fully = models_to_test + models_to_jit_test
 @pytest.mark.regression_test
 @pytest.mark.parametrize("model_name,jit", models_to_test_fully)
 def test_inference_with_data(
-        model_name,
-        jit,
-        pretrained = None,
-        pretrained_hf = False,
-        precision = 'fp32',
-        force_quick_gelu = False,
+    model_name,
+    jit,
+    pretrained=None,
+    pretrained_hf=False,
+    precision="fp32",
+    force_quick_gelu=False,
 ):
     util_test.seed_all()
     model, _, preprocess_val = open_clip.create_model_and_transforms(
-            model_name,
-            pretrained = pretrained,
-            precision = precision,
-            jit = jit,
-            force_quick_gelu = force_quick_gelu,
-            pretrained_hf = pretrained_hf
+        model_name,
+        pretrained=pretrained,
+        precision=precision,
+        jit=jit,
+        force_quick_gelu=force_quick_gelu,
+        pretrained_hf=pretrained_hf,
     )
-    model_id = f'{model_name}_{pretrained or pretrained_hf}_{precision}'
+    model_id = f"{model_name}_{pretrained or pretrained_hf}_{precision}"
     input_dir, output_dir = util_test.get_data_dirs()
     # text
-    input_text_path = os.path.join(input_dir, 'random_text.pt')
-    gt_text_path = os.path.join(output_dir, f'{model_id}_random_text.pt')
+    input_text_path = os.path.join(input_dir, "random_text.pt")
+    gt_text_path = os.path.join(output_dir, f"{model_id}_random_text.pt")
     if not os.path.isfile(input_text_path):
-        pytest.skip(reason = f"missing test data, expected at {input_text_path}")
+        pytest.skip(reason=f"missing test data, expected at {input_text_path}")
     if not os.path.isfile(gt_text_path):
-        pytest.skip(reason = f"missing test data, expected at {gt_text_path}")
+        pytest.skip(reason=f"missing test data, expected at {gt_text_path}")
     input_text = torch.load(input_text_path)
     gt_text = torch.load(gt_text_path)
     y_text = util_test.inference_text(model, model_name, input_text)
@@ -85,25 +85,29 @@ def test_inference_with_data(
     image_size = model.visual.image_size
     if not isinstance(image_size, tuple):
         image_size = (image_size, image_size)
-    input_image_path = os.path.join(input_dir, f'random_image_{image_size[0]}_{image_size[1]}.pt')
-    gt_image_path = os.path.join(output_dir, f'{model_id}_random_image.pt')
+    input_image_path = os.path.join(input_dir, f"random_image_{image_size[0]}_{image_size[1]}.pt")
+    gt_image_path = os.path.join(output_dir, f"{model_id}_random_image.pt")
     if not os.path.isfile(input_image_path):
-        pytest.skip(reason = f"missing test data, expected at {input_image_path}")
+        pytest.skip(reason=f"missing test data, expected at {input_image_path}")
     if not os.path.isfile(gt_image_path):
-        pytest.skip(reason = f"missing test data, expected at {gt_image_path}")
+        pytest.skip(reason=f"missing test data, expected at {gt_image_path}")
     input_image = torch.load(input_image_path)
     gt_image = torch.load(gt_image_path)
     y_image = util_test.inference_image(model, preprocess_val, input_image)
     assert (y_image == gt_image).all(), f"image output differs @ {input_image_path}"
-    
+
     if not jit:
         model.eval()
-        model_out = util_test.forward_model(model, model_name, preprocess_val, input_image, input_text)
+        model_out = util_test.forward_model(
+            model, model_name, preprocess_val, input_image, input_text
+        )
         if type(model) not in [open_clip.CLIP, open_clip.CustomTextCLIP]:
             assert type(model_out) == dict
         else:
             model.output_dict = True
-            model_out_dict = util_test.forward_model(model, model_name, preprocess_val, input_image, input_text)
+            model_out_dict = util_test.forward_model(
+                model, model_name, preprocess_val, input_image, input_text
+            )
             assert (model_out_dict["image_features"] == model_out[0]).all()
             assert (model_out_dict["text_features"] == model_out[1]).all()
             assert (model_out_dict["logit_scale"] == model_out[2]).all()
@@ -111,23 +115,23 @@ def test_inference_with_data(
     else:
         model, _, preprocess_val = open_clip.create_model_and_transforms(
             model_name,
-            pretrained = pretrained,
-            precision = precision,
-            jit = False,
-            force_quick_gelu = force_quick_gelu,
-            pretrained_hf = pretrained_hf
+            pretrained=pretrained,
+            precision=precision,
+            jit=False,
+            force_quick_gelu=force_quick_gelu,
+            pretrained_hf=pretrained_hf,
         )
-        
+
         test_model = util_test.TestWrapper(model, model_name, output_dict=False)
         test_model = torch.jit.script(test_model)
-        model_out = util_test.forward_model(test_model, model_name, preprocess_val, input_image, input_text)
+        model_out = util_test.forward_model(
+            test_model, model_name, preprocess_val, input_image, input_text
+        )
         assert model_out["test_output"].shape[-1] == 2
 
         test_model = util_test.TestWrapper(model, model_name, output_dict=True)
         test_model = torch.jit.script(test_model)
-        model_out = util_test.forward_model(test_model, model_name, preprocess_val, input_image, input_text)
+        model_out = util_test.forward_model(
+            test_model, model_name, preprocess_val, input_image, input_text
+        )
         assert model_out["test_output"].shape[-1] == 2
-        
-    
-
-


### PR DESCRIPTION
This PR changes context length in coca cfg while shortening it in the model init so the tokenizer will behave as it should.