### PR TITLE
Fix undesired behavior of `transform.PreprocessCfg`

### DIFF
--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -24,7 +24,7 @@ class PreprocessCfg:
     fill_color: int = 0
 
     def __post_init__(self):
-        assert self.mode in ('RGB')
+        assert self.mode in ('RGB',)
 
     @property
     def num_channels(self):
@@ -32,7 +32,7 @@ class PreprocessCfg:
 
     @property
     def input_size(self):
-        return (self.num_channels(),) + to_2tuple(self.size)
+        return (self.num_channels,) + to_2tuple(self.size)
 
 _PREPROCESS_KEYS = set(asdict(PreprocessCfg()).keys())
 


### PR DESCRIPTION
This PR fixes 2 things in `transform.PreprocessCfg`:
* An assert on `mode` was incorrectly checked. Note that `(var)` isn't the same as `(var,)`. The former is the same as `var`, with redundant parentheses. The assert was working because the following is true `"RGB in "RGB"`.
* `PreprocessCfg.num_channels` is not a function but a property, so it doesn't carry parentheses.