### PR TITLE
Fix `model.get_model_preprocess_cfg`

### DIFF
--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -580,10 +580,10 @@ def get_model_preprocess_cfg(model):
             preprocess_cfg['size'] = size
         mean = getattr(module, 'image_mean', None)
         if mean is not None:
-            preprocess_cfg['mean'] = getattr(module, 'mean')
+            preprocess_cfg['mean'] = mean
         std = getattr(module, 'image_std', None)
         if std is not None:
-            preprocess_cfg['std'] = getattr(module, 'std')
+            preprocess_cfg['std'] = std
     return preprocess_cfg
 
 


### PR DESCRIPTION
For this PR, I'm not 100% sure it's a bug but it feels like it is. This function first checks there's an "image_mean" attribute but then gets a different one ("mean"). Similarly for "std". So it fixes this.