### PR TITLE
Make Text Embedding Normalization During Zero Shot Inference Consistent With Training

### DIFF
--- a/src/open_clip/zero_shot_classifier.py
+++ b/src/open_clip/zero_shot_classifier.py
@@ -53,7 +53,7 @@ def build_zero_shot_classifier(
         num_batch_classes = len(batch_classnames)
         texts = [template.format(c) if use_format else template(c) for c in batch_classnames for template in templates]
         texts = tokenizer(texts).to(device)
-        class_embeddings = F.normalize(model.encode_text(texts), dim=-1)
+        class_embeddings = model.encode_text(texts, normalize=True)
         class_embeddings = class_embeddings.reshape(num_batch_classes, num_templates, -1).mean(dim=1)
         class_embeddings = class_embeddings / class_embeddings.norm(dim=1, keepdim=True)
         class_embeddings = class_embeddings.T


### PR DESCRIPTION
This is a minor change but makes things more consistent, as the training code also normalizes embeddings by using the flag in `encode_text`:
https://github.com/mlfoundations/open_clip/blob/a6bb37c7e24222e1aafd75e752b1877fa9c3278f/src/open_clip/model.py#L294