### PR TITLE
Fix missing return of "logit_bias" in `CoCa.forward`

### DIFF
--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -173,13 +173,16 @@ class CoCa(nn.Module):
         labels = text[:, -token_embs.shape[1]:]
 
         logits = self.text_decoder(image_embs, token_embs)
-        return {
+        out_dict = {
             "image_features": image_latent,
             "text_features": text_latent,
             "logits": logits,
             "labels": labels,
             "logit_scale": self.logit_scale.exp()
         }
+        if self.logit_bias is not None:
+            out_dict["logit_bias"] = self.logit_bias
+        return out_dict
 
     def generate(
         self,


### PR DESCRIPTION
I recently saw the following change that adds `logit_bias` to `CoCa`: https://github.com/mlfoundations/open_clip/commit/6f05e1dfe9d19782978466f4a815c44bcf40ad6a

However, I think it misses using this parameter if it's non-null. This PR changes this, to use it as in `CLIP` or `CustomTextCLIP`.