### PR TITLE
Fix clipa tokenizer documentation

### DIFF
--- a/docs/clipa.md
+++ b/docs/clipa.md
@@ -37,15 +37,15 @@ Eight token length reduction strategies are investigated in this work, detailed 
 
 ## Text token length reduction
 
-* `syntax mask`: Assign different masking priorities to parts of speech. Specify `"text_mask": syntax` in `"text_cfg"` of model config `json` file to use. 
+* `syntax mask`: Assign different masking priorities to parts of speech. Specify `"text_mask": syntax` in `#tokenizer_kwargs` in `"text_cfg"` of model config `json` file to use. 
 Specifically, we prioritize retaining nouns, followed by adjectives, and then other words. 
 We find this strategy generally works the best as it retains critical information for contrastive learning.
 
 * `truncate`: Truncation selects the first N text tokens and discards the rest. This is the default setting of `open_clip`. 
 
-* `random mask`: Randomly drops a portion of the text tokens. Specify `"text_mask": random` in `"text_cfg"` of model config `json` file to use. 
+* `random mask`: Randomly drops a portion of the text tokens. Specify `"text_mask": random` in `#tokenizer_kwargs in `"text_cfg"` of model config `json` file to use. 
 
-* `block mask`: Randomly preserves consecutive text sequences. Specify `"text_mask": block` in `"text_cfg"` of model config `json` file to use. 
+* `block mask`: Randomly preserves consecutive text sequences. Specify `"text_mask": block` in `#tokenizer_kwargs in `"text_cfg"` of model config `json` file to use. 
 
 
 ## Installation

--- a/docs/clipa.md
+++ b/docs/clipa.md
@@ -37,15 +37,15 @@ Eight token length reduction strategies are investigated in this work, detailed 
 
 ## Text token length reduction
 
-* `syntax mask`: Assign different masking priorities to parts of speech. Specify `"text_mask": syntax` in `#tokenizer_kwargs` in `"text_cfg"` of model config `json` file to use. 
+* `syntax mask`: Assign different masking priorities to parts of speech. Specify `"text_mask": syntax` in `"tokenizer_kwargs"` in `"text_cfg"` of model config `json` file to use. 
 Specifically, we prioritize retaining nouns, followed by adjectives, and then other words. 
 We find this strategy generally works the best as it retains critical information for contrastive learning.
 
 * `truncate`: Truncation selects the first N text tokens and discards the rest. This is the default setting of `open_clip`. 
 
-* `random mask`: Randomly drops a portion of the text tokens. Specify `"text_mask": random` in `#tokenizer_kwargs in `"text_cfg"` of model config `json` file to use. 
+* `random mask`: Randomly drops a portion of the text tokens. Specify `"text_mask": random` in `"tokenizer_kwargs"` in `"text_cfg"` of model config `json` file to use. 
 
-* `block mask`: Randomly preserves consecutive text sequences. Specify `"text_mask": block` in `#tokenizer_kwargs in `"text_cfg"` of model config `json` file to use. 
+* `block mask`: Randomly preserves consecutive text sequences. Specify `"text_mask": block` in `"tokenizer_kwargs"` in `"text_cfg"` of model config `json` file to use. 
 
 
 ## Installation


### PR DESCRIPTION
The CLIPA tokenizer description as it exists right now isn't exactly correct. In order to use any of the masking you need to add 
```
"tokenizer_kwargs": {
            "reduction_mask": "syntax"
        }
```
as a configuration within `text_cfg`.  This PR fixes the documentation.