### PR TITLE
Update modified_resnet.py : Correct import path

### DIFF
--- a/src/open_clip/modified_resnet.py
+++ b/src/open_clip/modified_resnet.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from open_clip.utils import freeze_batch_norm_2d
+from .utils import freeze_batch_norm_2d
 
 
 class Bottleneck(nn.Module):


### PR DESCRIPTION
Seems like wrong path for utils have been provided in the import which gives error while using this line : `from src import open_clip`