### PR TITLE
safetensors support when loading from hf_hub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ regex
 ftfy
 tqdm
 huggingface_hub
+safetensors
 sentencepiece
 protobuf
 timm

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -144,6 +144,10 @@ def load_checkpoint(model, checkpoint_path, strict=True):
         from .big_vision import load_big_vision_weights
         load_big_vision_weights(model, checkpoint_path)
         return {}
+    elif Path(checkpoint_path).suffix in ('.safetensors',):
+        from safetensors.torch import load_model
+        load_model(model, checkpoint_path)
+        return {}
 
     state_dict = load_state_dict(checkpoint_path)
     # detect old format and make compatible with new format


### PR DESCRIPTION
**Changes**

- requirements file includes safetensors import
- load_checkpoint function now loads safetensors if there's .safetensors suffix
- download_pretrained_from_hf function checks for .bin file first, and if that isn't found, checks for .safetensors file

**Why is this important?**
With safetensors being much faster in loading up the weights, this is a helpful change for the repository. These modifications only come into effect if the HF repository does not have the .bin file, therefore, there would be no changes to the current open_clip users. My changes only come into effect if the .bin file is missing, and instead of raising an Exception, it checks the repo again for .safetensors file before doing so.