### PR TITLE
fix repetition 'sunglasses' label

### DIFF
--- a/src/open_clip/zero_shot_metadata.py
+++ b/src/open_clip/zero_shot_metadata.py
@@ -237,7 +237,7 @@ IMAGENET_CLASSNAMES = (
     "space shuttle", "spatula", "motorboat", "spider web", "spindle", "sports car", "spotlight",
     "stage", "steam locomotive", "through arch bridge", "steel drum", "stethoscope", "scarf",
     "stone wall", "stopwatch", "stove", "strainer", "tram", "stretcher", "couch", "stupa",
-    "submarine", "suit", "sundial", "sunglasses", "sunglasses", "sunscreen", "suspension bridge",
+    "submarine", "suit", "sundial", "sunglass", "sunglasses / dark glasses / shades", "sunscreen", "suspension bridge",
     "mop", "sweatshirt", "swim trunks / shorts", "swing", "electrical switch", "syringe",
     "table lamp", "tank", "tape player", "teapot", "teddy bear", "television", "tennis ball",
     "thatched roof", "front curtain", "thimble", "threshing machine", "throne", "tile roof",


### PR DESCRIPTION
There was a repetition "sunglasses" at IMAGENET_CLASSES.
As far as I understand, these class names have already been corrected (for instance, 'crane' transform into "crane bird" and "construction crane", but "sunglasses" haven't been).
Reference: https://www.kaggle.com/c/imagenet-object-localization-challenge/data?select=LOC_synset_mapping.txt 

The desired mapping {folder name: class name}:
n04355933 sunglass
n04356056 sunglasses, dark glasses, shades

I have added this difference so that there are 1000 unique labels.