### PR TITLE
Fix stopping_criteria result check in coca_model

### DIFF
--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -23,6 +23,8 @@ try:
         RepetitionPenaltyLogitsProcessor,
         MinLengthLogitsProcessor,
         MaxLengthCriteria,
+        StopStringCriteria,
+        EosTokenCriteria,
         StoppingCriteriaList
     )
 
@@ -298,7 +300,12 @@ class CoCa(nn.Module):
 
                 cur_len += 1
 
-                if stopping_criteria(out, None).any():
+                is_done = False
+                if EosTokenCriteria in stopping_criteria or StopStringCriteria in stopping_criteria:
+                    is_done = stopping_criteria(out, None).all()
+                else:
+                    is_done = stopping_criteria(out, None).any()
+                if is_done:
                     break
 
             if num_dims == 1:
@@ -439,7 +446,14 @@ class CoCa(nn.Module):
 
             # increase cur_len
             cur_len = cur_len + 1
-            if beam_scorer.is_done or stopping_criteria(input_ids, None).any():
+            is_done = False
+            if EosTokenCriteria in stopping_criteria or StopStringCriteria in stopping_criteria:
+                is_done = stopping_criteria(input_ids, None).all()
+            else:
+                is_done = stopping_criteria(input_ids, None).any()
+            if is_done:
+                break
+            if beam_scorer.is_done or is_done:
                 break
 
         final_beam_indices = sum(beam_indices, ()) if beam_indices is not None else None

--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -298,7 +298,7 @@ class CoCa(nn.Module):
 
                 cur_len += 1
 
-                if stopping_criteria(out, None):
+                if stopping_criteria(out, None).any():
                     break
 
             if num_dims == 1:
@@ -439,7 +439,7 @@ class CoCa(nn.Module):
 
             # increase cur_len
             cur_len = cur_len + 1
-            if beam_scorer.is_done or stopping_criteria(input_ids, None):
+            if beam_scorer.is_done or stopping_criteria(input_ids, None).any():
                 break
 
         final_beam_indices = sum(beam_indices, ()) if beam_indices is not None else None


### PR DESCRIPTION
**fix #847**

The stopping criteria is updated in the latest `transformers`(V4.39.3 now). The return result is modified to a tensor (`torch.full((input_ids.shape[0],), is_done, device=input_ids.device, dtype=torch.bool)` ) instead of a bool value, which causes the bug in #847

**the related code in `transformers`**
https://github.com/huggingface/transformers/blob/0bd58f1ce0573c0e3269de4215a17d318add49b9/src/transformers/generation/stopping_criteria.py#L76