### PR TITLE
add missing ViTamin configs

### DIFF
--- a/src/open_clip/model_configs/ViTamin-L-384.json
+++ b/src/open_clip/model_configs/ViTamin-L-384.json
@@ -1,0 +1,20 @@
+{
+    "embed_dim": 768,
+    "vision_cfg": {
+      "timm_model_name": "vitamin_large_384",
+      "timm_model_pretrained": false,
+      "timm_pool": "",
+      "timm_proj": "linear",
+      "timm_drop": 0.0,
+      "timm_drop_path": 0.1,
+      "image_size": 384
+    },
+    "text_cfg": {
+      "context_length": 77,
+      "vocab_size": 49408,
+      "width": 768,
+      "heads": 12,
+      "layers": 12
+    },
+    "custom_text": true
+}

--- a/src/open_clip/model_configs/ViTamin-L2-384.json
+++ b/src/open_clip/model_configs/ViTamin-L2-384.json
@@ -1,0 +1,20 @@
+{
+    "embed_dim": 1024,
+    "vision_cfg": {
+      "timm_model_name": "vitamin_large2_384",
+      "timm_model_pretrained": false,
+      "timm_pool": "",
+      "timm_proj": "linear",
+      "timm_drop": 0.0,
+      "timm_drop_path": 0.1,
+      "image_size": 384
+    },
+    "text_cfg": {
+      "context_length": 77,
+      "vocab_size": 49408,
+      "width": 1024,
+      "heads": 16,
+      "layers": 24
+    },
+    "custom_text": true
+}


### PR DESCRIPTION
In `src/open_clip/model_configs`, two configs of the ViTamin series are missing: `ViTamin-L-384` and `ViTamin-L2-384`.

The two added models are evaluated (with pretrained weights) on the Datacomp benchmark, where `ViTamin-L-384` has 81.83% ImageNet top 1 and 67.12% Average, and `ViTamin-L2-384` has 82.05% ImageNet top 1 and 67.97% Average, matching the performance reported in the paper.