### PR TITLE
Fix ViT-SO400M-14-SigLIP context length

### DIFF
--- a/src/open_clip/model_configs/ViT-SO400M-14-SigLIP.json
+++ b/src/open_clip/model_configs/ViT-SO400M-14-SigLIP.json
@@ -10,7 +10,7 @@
         "timm_proj": "none"
     },
     "text_cfg": {
-        "context_length": 16,
+        "context_length": 64,
         "vocab_size": 32000,
         "hf_tokenizer_name": "timm/ViT-B-16-SigLIP",
         "tokenizer_kwargs": {


### PR DESCRIPTION
According to paper all SigLIP models have context length = 64