### PR TITLE
API for getting intermediate image and text features, forward_intermediates()

### DIFF
--- a/src/open_clip/coca_model.py
+++ b/src/open_clip/coca_model.py
@@ -221,7 +221,7 @@ class CoCa(nn.Module):
                 output_fmt=image_output_fmt,
                 output_extra_tokens=image_output_extra_tokens,
             )
-            if normalize:
+            if normalize and "image_features" in image_output:
                 image_output["image_features"] = F.normalize(image_output["image_features"], dim=-1)
             output.update(image_output)
 
@@ -235,7 +235,7 @@ class CoCa(nn.Module):
                 output_fmt=text_output_fmt,
                 output_extra_tokens=text_output_extra_tokens,
             )
-            if normalize:
+            if normalize and "text_features" in text_output:
                 text_output["text_features"] = F.normalize(text_output["text_features"], dim=-1)
             output.update(text_output)
 

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -360,7 +360,7 @@ class CLIP(nn.Module):
                 output_fmt=image_output_fmt,
                 output_extra_tokens=image_output_extra_tokens,
             )
-            if normalize:
+            if normalize and "image_features" in image_output:
                 image_output["image_features"] = F.normalize(image_output["image_features"], dim=-1)
             output.update(image_output)
 
@@ -556,7 +556,7 @@ class CustomTextCLIP(nn.Module):
                 output_fmt=image_output_fmt,
                 output_extra_tokens=image_output_extra_tokens,
             )
-            if normalize:
+            if normalize and "image_features" in image_output:
                 image_output["image_features"] = F.normalize(image_output["image_features"], dim=-1)
             output.update(image_output)
 
@@ -570,7 +570,7 @@ class CustomTextCLIP(nn.Module):
                 output_fmt=text_output_fmt,
                 output_extra_tokens=text_output_extra_tokens,
             )
-            if normalize:
+            if normalize and "text_features" in text_output:
                 text_output["text_features"] = F.normalize(text_output["text_features"], dim=-1)
             output.update(text_output)
 

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -339,6 +339,12 @@ class CLIP(nn.Module):
 
         """
         output = {}
+        if intermediates_only:
+            # intermediates only disables final feature normalization, and include logits
+            normalize = False
+            include_logits = False
+        if include_logits:
+            assert image is not None and text is not None, 'Both image and text inputs are required to compute logits'
 
         if image is not None:
             image_output = self.visual.forward_intermediates(
@@ -529,10 +535,12 @@ class CustomTextCLIP(nn.Module):
 
         """
         output = {}
+        if intermediates_only:
+            # intermediates only disables final feature normalization, and include logits
+            normalize = False
+            include_logits = False
         if include_logits:
             assert image is not None and text is not None, 'Both image and text inputs are required to compute logits'
-        if include_logits:
-            intermediates_only = False
 
         if image is not None:
             image_output = self.visual.forward_intermediates(

--- a/src/open_clip/modified_resnet.py
+++ b/src/open_clip/modified_resnet.py
@@ -1,10 +1,11 @@
 from collections import OrderedDict
+from typing import Dict, List, Optional, Union
 
 import torch
 from torch import nn
 from torch.nn import functional as F
 
-from open_clip.utils import freeze_batch_norm_2d
+from .utils import freeze_batch_norm_2d, feature_take_indices
 
 
 class Bottleneck(nn.Module):
@@ -96,11 +97,18 @@ class ModifiedResNet(nn.Module):
     """
     A ResNet class that is similar to torchvision's but contains the following changes:
     - There are now 3 "stem" convolutions as opposed to 1, with an average pool instead of a max pool.
-    - Performs anti-aliasing strided convolutions, where an avgpool is prepended to convolutions with stride > 1
+    - Performs antialiasing strided convolutions, where an avgpool is prepended to convolutions with stride > 1
     - The final pooling layer is a QKV attention instead of an average pool
     """
 
-    def __init__(self, layers, output_dim, heads, image_size=224, width=64):
+    def __init__(
+            self,
+            layers: List[int],
+            output_dim: int,
+            heads: int,
+            image_size: int = 224,
+            width: int = 64,
+    ):
         super().__init__()
         self.output_dim = output_dim
         self.image_size = image_size
@@ -169,6 +177,53 @@ class ModifiedResNet(nn.Module):
         x = self.act3(self.bn3(self.conv3(x)))
         x = self.avgpool(x)
         return x
+
+    def forward_intermediates(
+            self,
+            x: torch.Tensor,
+            indices: Optional[Union[int, List[int]]] = None,
+            return_extra_tokens: bool = False,
+            normalize_intermediates: bool = False,
+            stop_early: bool = False,
+            output_fmt: str = 'NCHW',
+            intermediates_only: bool = False,
+    ) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:
+        """ Forward features that returns intermediates.
+
+        Args:
+            x: Input image tensor
+            indices: Take last n blocks if int, all if None, select matching indices if sequence
+            return_extra_tokens: Return both extra class, eot tokens
+            normalize_intermediates: Apply final norm layer to all intermediates
+            stop_early: Stop iterating over blocks when last desired intermediate hit
+            output_fmt: Shape of intermediate feature outputs
+            intermediates_only: Only return intermediate features
+        Returns:
+
+        """
+        assert output_fmt in ('NCHW',), 'Output format must be == NCHW.'
+        # NOTE normalize_intermediates and return_extra_tokens don't apply
+        take_indices, max_index = feature_take_indices(5, indices)
+
+        output = {}
+        intermediates = []
+        blocks = [self.stem, self.layer1, self.layer2, self.layer3, self.layer4]
+        if torch.jit.is_scripting() or not stop_early:  # can't slice blocks in torchscript
+            blocks = blocks[:max_index + 1]
+        for i, blk in enumerate(blocks):
+            x = blk(x)
+            if i in take_indices:
+                intermediates.append(x)
+
+        output['image_intermediates'] = intermediates
+
+        if intermediates_only:
+            return output
+
+        x = self.attnpool(x)
+        output['image_features'] = x
+
+        return output
 
     def forward(self, x):
         x = self.stem(x)

--- a/src/open_clip/modified_resnet.py
+++ b/src/open_clip/modified_resnet.py
@@ -182,22 +182,22 @@ class ModifiedResNet(nn.Module):
             self,
             x: torch.Tensor,
             indices: Optional[Union[int, List[int]]] = None,
-            return_extra_tokens: bool = False,
-            normalize_intermediates: bool = False,
             stop_early: bool = False,
-            output_fmt: str = 'NCHW',
+            normalize_intermediates: bool = False,
             intermediates_only: bool = False,
+            output_fmt: str = 'NCHW',
+            output_extra_tokens: bool = False,
     ) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:
         """ Forward features that returns intermediates.
 
         Args:
             x: Input image tensor
             indices: Take last n blocks if int, all if None, select matching indices if sequence
-            return_extra_tokens: Return both extra class, eot tokens
-            normalize_intermediates: Apply final norm layer to all intermediates
             stop_early: Stop iterating over blocks when last desired intermediate hit
-            output_fmt: Shape of intermediate feature outputs
+            normalize_intermediates: Apply final norm layer to all intermediates
             intermediates_only: Only return intermediate features
+            output_fmt: Shape of intermediate feature outputs
+            output_extra_tokens: Return both extra class, eot tokens
         Returns:
 
         """

--- a/src/open_clip/timm_model.py
+++ b/src/open_clip/timm_model.py
@@ -145,8 +145,8 @@ class TimmModel(nn.Module):
             self,
             x: torch.Tensor,
             indices: Optional[Union[int, List[int]]] = None,
-            return_prefix_tokens: bool = False,
-            norm: bool = False,
+            return_extra_tokens: bool = False,
+            normalize_intermediates: bool = False,
             stop_early: bool = False,
             output_fmt: str = 'NCHW',
             intermediates_only: bool = False,
@@ -156,18 +156,18 @@ class TimmModel(nn.Module):
         Args:
             x: Input image tensor
             indices: Take last n blocks if int, all if None, select matching indices if sequence
-            return_prefix_tokens: Return both prefix and spatial intermediate tokens
-            norm: Apply norm layer to all intermediates
+            return_extra_tokens: Return both prefix and spatial intermediate tokens
+            normalize_intermediates: Apply norm layer to all intermediates
             stop_early: Stop iterating over blocks when last desired intermediate hit
             output_fmt: Shape of intermediate feature outputs
             intermediates_only: Only return intermediate features
         Returns:
         """
-        output = self.trunk.get_intermediates(
+        output = self.trunk.forward_intermediates(
                 x,
                 indices=indices,
-                return_prefix_tokens=return_prefix_tokens,
-                norm=norm,
+                return_prefix_tokens=return_extra_tokens,
+                norm=normalize_intermediates,
                 stop_early=stop_early,
                 output_fmt=output_fmt,
                 intermediates_only=intermediates_only,

--- a/src/open_clip/timm_model.py
+++ b/src/open_clip/timm_model.py
@@ -145,34 +145,34 @@ class TimmModel(nn.Module):
             self,
             x: torch.Tensor,
             indices: Optional[Union[int, List[int]]] = None,
-            return_extra_tokens: bool = False,
-            normalize_intermediates: bool = False,
             stop_early: bool = False,
-            output_fmt: str = 'NCHW',
+            normalize_intermediates: bool = False,
             intermediates_only: bool = False,
+            output_fmt: str = 'NCHW',
+            output_extra_tokens: bool = False,
     ) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:
         """ Forward features that returns intermediates.
 
         Args:
             x: Input image tensor
             indices: Take last n blocks if int, all if None, select matching indices if sequence
-            return_extra_tokens: Return both prefix and spatial intermediate tokens
-            normalize_intermediates: Apply norm layer to all intermediates
             stop_early: Stop iterating over blocks when last desired intermediate hit
-            output_fmt: Shape of intermediate feature outputs
+            normalize_intermediates: Apply norm layer to all intermediates
             intermediates_only: Only return intermediate features
+            output_fmt: Shape of intermediate feature outputs
+            output_extra_tokens: Return both prefix and spatial intermediate tokens
         Returns:
         """
         extra_args = {}
-        if return_extra_tokens:
+        if output_extra_tokens:
             extra_args['return_prefix_tokens'] = True
         output = self.trunk.forward_intermediates(
                 x,
                 indices=indices,
+                intermediates_only=intermediates_only,
                 norm=normalize_intermediates,
                 stop_early=stop_early,
                 output_fmt=output_fmt,
-                intermediates_only=intermediates_only,
                 **extra_args,
             )
 

--- a/src/open_clip/transformer.py
+++ b/src/open_clip/transformer.py
@@ -1189,8 +1189,10 @@ class MultimodalTransformer(Transformer):
         for resblock, cross_attn in zip(self.resblocks, self.cross_attn):
             if self.grad_checkpointing and not torch.jit.is_scripting():
                 # TODO: handle kwargs https://github.com/pytorch/pytorch/issues/79887#issuecomment-1161758372
-                text_embs = checkpoint(resblock, text_embs, None, None, self.attn_mask[:seq_len, :seq_len])
-                text_embs = checkpoint(cross_attn, text_embs, image_embs, image_embs, None)
+                text_embs = checkpoint(
+                    resblock, text_embs, None, None, self.attn_mask[:seq_len, :seq_len], use_reentrant=False)
+                text_embs = checkpoint(
+                    cross_attn, text_embs, image_embs, image_embs, None, use_reentrant=False)
             else:
                 text_embs = resblock(text_embs, attn_mask=self.attn_mask[:seq_len, :seq_len])
                 text_embs = cross_attn(text_embs, k_x=image_embs, v_x=image_embs)


### PR DESCRIPTION
Compatible with timm approach (passes through to timm image encoders) and adding to builtin image and text...

This is a different approach than #731, but as with timm, I found the idea of integrating the output_hidden_states approach to be like HF Transformers to be a bit of a headache and risk too many regressions. This approach duplicates some code, but it makes typing less problematic, and keeps the main forward functions lean for training, normal use.