### PR TITLE
Load huggingface model and tokenizer from local path

### DIFF
--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -122,15 +122,17 @@ def get_tokenizer(
     if context_length is None:
         context_length = text_config.get('context_length', DEFAULT_CONTEXT_LENGTH)
 
-    model_name = model_name.lower()
     if text_config.get('hf_tokenizer_name', ''):
         tokenizer = HFTokenizer(
-            text_config['hf_tokenizer_name'],
+            model_name,
             context_length=context_length,
             cache_dir=cache_dir,
             **tokenizer_kwargs,
         )
-    elif 'siglip' in model_name:
+        return tokenizer
+    
+    model_name = model_name.lower()
+    if 'siglip' in model_name:
         tn = 'gemma' if 'siglip2'  in model_name else 'mc4' if 'i18n' in model_name else 'c4-en'
         tokenizer = SigLipTokenizer(
             tn,

--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -782,7 +782,8 @@ def download_pretrained_from_hf(
     has_hf_hub(True)
 
     filename = filename or HF_WEIGHTS_NAME
-
+    if os.path.isfile(os.path.join(model_id, filename)):
+        return os.path.join(model_id, filename)
     # Look for .safetensors alternatives and load from it if it exists
     if _has_safetensors:
         for safe_filename in _get_safe_alternatives(filename):


### PR DESCRIPTION
Load huggingface model and tokenizer from local path

For example, I want to load `timm/ViT-SO400M-14-SigLIP` from a local path, the usage is:

```python
import open_clip

local_hf_model_path = "/path/to/timm/ViT-SO400M-14-SigLIP"
model, preprocess = open_clip.create_model_from_pretrained(f"hf-hub:{local_hf_model_path}")
tokenizer = open_clip.get_tokenizer(f"hf-hub:{local_hf_model_path}")
```