### PR TITLE
fix CustomTextCLIP.no_weight_decay

### DIFF
--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -480,7 +480,7 @@ class CustomTextCLIP(nn.Module):
             for n in self.visual.no_weight_decay():
                 no_wd.add('visual.' + n)
         if hasattr(self.text, 'no_weight_decay'):
-            for n in self.visual.no_weight_decay():
+            for n in self.text.no_weight_decay():
                 no_wd.add('text.' + n)
         return no_wd
 


### PR DESCRIPTION
In CustomTextCLIP.no_weight_decay we check if the text tower has a no_weight_decay function, but we call the image tower function instead of the one from the text tower.