### PR TITLE
Remove non-existent MetaCLIP 2 L/14 checkpoint

### DIFF
--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -681,12 +681,6 @@ _PRETRAINED = {
     ),
 
     # MetaCLIP 2
-    "ViT-L-14-worldwide": dict(
-        metaclip2_worldwide=_pcfg(
-            hf_hub="timm/vit_large_patch14_clip_224.metaclip2_worldwide/",
-            quick_gelu=True,
-        ),
-    ),
     "ViT-H-14-worldwide": dict(
         metaclip2_worldwide=_pcfg(
             hf_hub="timm/vit_huge_patch14_clip_224.metaclip2_worldwide/",


### PR DESCRIPTION
This PR removes the MetaCLIP 2 L/14 model checkpoint entry that does not exist anymore.

- This model was invalid / not hosted anymore: https://huggingface.co/timm/vit_large_patch14_clip_224.metaclip2_worldwide
- Keeping the entry may cause confusion for users trying to load the model
- Other MetaCLIP 2 checkpoints are untouched

This change ensures that only available and verified checkpoints remain in the model registry.