### PR TITLE
factory.load_state_dict: remove unreachable except TypeError fallback

### DIFF
--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -160,10 +160,7 @@ def load_state_dict(
         from safetensors.torch import load_file
         checkpoint = load_file(checkpoint_path, device=device)
     else:
-        try:
-            checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=weights_only)
-        except TypeError:
-            checkpoint = torch.load(checkpoint_path, map_location=device)
+        checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=weights_only)
 
     if isinstance(checkpoint, dict) and 'state_dict' in checkpoint:
         state_dict = checkpoint['state_dict']


### PR DESCRIPTION
Removes the `try/except TypeError` fallback around `torch.load(..., weights_only=weights_only)` in `load_state_dict`. Under `torch>=2.0` (pinned in `pyproject.toml`) the kwarg is always accepted, so the fallback branch is unreachable. Removing it keeps `weights_only` a hard guarantee rather than a try-first/drop-on-TypeError soft hint, matching the direction of #967.

Fixes #1148