### PR TITLE
Fix text_global_pool eos pool_type when eos_token_id is absent from sequence

### DIFF
--- a/src/open_clip/transformer.py
+++ b/src/open_clip/transformer.py
@@ -936,7 +936,15 @@ def text_global_pool(
         # take features from tokenizer specific eos
         assert text is not None
         assert eos_token_id is not None
-        idx = (text == eos_token_id).int().argmax(dim=-1)
+        mask = (text == eos_token_id)
+        has_eos = mask.any(dim=-1)
+        # Fall back to the last position when EOS is absent (e.g. truncated input)
+        # so that we never silently pool from position 0 (BOS/CLS).
+        idx = torch.where(
+            has_eos,
+            mask.int().argmax(dim=-1),
+            torch.full((text.size(0),), text.size(1) - 1, dtype=torch.long, device=text.device),
+        )
         pooled = x[torch.arange(x.shape[0], device=x.device), idx]
     else:
         pooled = x

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -130,6 +130,23 @@ def test_inference_with_data(
         test_model = torch.jit.script(test_model)
         model_out = util_test.forward_model(test_model, model_name, preprocess_val, input_image, input_text)
         assert model_out["test_output"].shape[-1] == 2
+
+
+def test_text_global_pool_eos_fallback_to_last_position():
+    """When eos_token_id is absent from a row, pool_type='eos' should fall back
+    to the last position rather than silently returning x[:, 0] (the BOS/CLS
+    position). Guards against silent-wrong-result on truncated inputs.
+    """
+    from open_clip.transformer import text_global_pool
+    eos = 49407
+    x = torch.arange(2 * 8 * 4, dtype=torch.float32).reshape(2, 8, 4)
+    text = torch.tensor([
+        [1, 2, 3, eos, 0, 0, 0, 0],     # has EOS at position 3
+        [1, 2, 3, 4, 5, 6, 7, 8],       # no EOS anywhere
+    ])
+    pooled = text_global_pool(x, text, pool_type='eos', eos_token_id=eos)
+    assert torch.equal(pooled[0], x[0, 3])     # row with EOS -> position 3
+    assert torch.equal(pooled[1], x[1, -1])    # row without EOS -> last position, not BOS
         
     
 


### PR DESCRIPTION
## Problem

`text_global_pool(pool_type='eos')` uses `(text == eos_token_id).int().argmax(dim=-1)` to locate the EOS position. When a row has no match, `argmax` on an all-zeros tensor returns index `0` — silently pooling the BOS/CLS position instead of EOS. The MetaCLIP2 WorldWide configs added in #1100 all use `pool_type: "eos"`, so any long input truncated before the EOS currently produces text features from position 0 without any warning.

## Fix

Fall back to the last position (`seq_len - 1`) rather than position 0 when EOS is absent. Behaviour is unchanged for valid inputs; truncated inputs now pool a reasonable end-of-sequence position.

```python
mask = (text == eos_token_id)
has_eos = mask.any(dim=-1)
idx = torch.where(has_eos, mask.int().argmax(dim=-1),
                  torch.full((text.size(0),), text.size(1) - 1,
                             dtype=torch.long, device=text.device))
```

## Test

Adds a unit test in `tests/test_inference.py` covering (a) normal case with EOS and (b) EOS-absent case, asserting the pooled feature matches the last-position feature rather than the BOS one.

Fixes #1151