### PR TITLE
Hoist DDP unwrap to top of evaluate() so zero_shot_eval runs on bare module

### DIFF
--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -254,6 +254,10 @@ def evaluate(model, data, epoch, args, tb_writer=None, tokenizer=None):
         return metrics
     device = torch.device(args.device)
     model.eval()
+    # unwrap DDP once here so zero_shot_eval and the imagenet-val / imagenet-v2
+    # paths below all run on the bare module on rank 0 (completes #1134).
+    if args.distributed and not args.horovod and hasattr(model, "module"):
+        model = model.module
 
     zero_shot_metrics = zero_shot_eval(model, data, epoch, args, tokenizer=tokenizer)
     metrics.update(zero_shot_metrics)
@@ -262,9 +266,6 @@ def evaluate(model, data, epoch, args, tb_writer=None, tokenizer=None):
     input_dtype = get_input_dtype(args.precision)
 
     if 'val' in data and (args.val_frequency and ((epoch % args.val_frequency) == 0 or epoch == args.epochs)):
-        # unwrap DDP for single process eval
-        if args.distributed and not args.horovod:
-            model = model.module
         dataloader = data['val'].dataloader
         num_samples = 0
         samples_per_val = dataloader.num_samples

--- a/src/open_clip_train/zero_shot.py
+++ b/src/open_clip_train/zero_shot.py
@@ -49,7 +49,7 @@ def zero_shot_eval(model, data, epoch, args, tokenizer=None):
         return {}
     if (epoch % args.zeroshot_frequency) != 0 and epoch != args.epochs:
         return {}
-    if args.distributed and not args.horovod:
+    if args.distributed and not args.horovod and hasattr(model, 'module'):
         model = model.module
 
     logging.info('Starting zero-shot imagenet.')

--- a/tests/test_zero_shot_eval.py
+++ b/tests/test_zero_shot_eval.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+from open_clip_train import zero_shot as zero_shot_module
+
+
+class _BareModel:
+    pass
+
+
+class _WrappedModel:
+    def __init__(self, module):
+        self.module = module
+
+
+class _DataWrapper:
+    def __init__(self):
+        self.dataloader = object()
+
+
+def test_zero_shot_eval_handles_already_unwrapped_model(monkeypatch):
+    bare_model = _BareModel()
+    build_models = []
+    run_models = []
+
+    monkeypatch.setattr(zero_shot_module, "get_tokenizer", lambda _model: object())
+
+    class _NullContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(zero_shot_module, "get_autocast", lambda *_args, **_kwargs: _NullContext)
+    monkeypatch.setattr(
+        zero_shot_module,
+        "build_zero_shot_classifier",
+        lambda model, **_kwargs: build_models.append(model) or object(),
+    )
+
+    def _run(model, classifier, dataloader, args):
+        run_models.append(model)
+        return 1.0, 1.0
+
+    monkeypatch.setattr(zero_shot_module, "run", _run)
+
+    args = SimpleNamespace(
+        distributed=True,
+        horovod=False,
+        zeroshot_frequency=1,
+        epochs=1,
+        model="ViT-B-32",
+        device="cpu",
+        precision="fp32",
+        batch_size=1,
+    )
+    data = {"imagenet-val": _DataWrapper()}
+
+    results = zero_shot_module.zero_shot_eval(bare_model, data, epoch=1, args=args)
+
+    assert results["imagenet-zeroshot-val-top1"] == 1.0
+    assert build_models == [bare_model]
+    assert run_models == [bare_model]
+
+
+def test_zero_shot_eval_unwraps_wrapped_model_once(monkeypatch):
+    bare_model = _BareModel()
+    wrapped_model = _WrappedModel(bare_model)
+    build_models = []
+    run_models = []
+
+    class _NullContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(zero_shot_module, "get_autocast", lambda *_args, **_kwargs: _NullContext)
+    monkeypatch.setattr(zero_shot_module, "get_tokenizer", lambda _model: object())
+    monkeypatch.setattr(
+        zero_shot_module,
+        "build_zero_shot_classifier",
+        lambda model, **_kwargs: build_models.append(model) or object(),
+    )
+
+    def _run(model, classifier, dataloader, args):
+        run_models.append(model)
+        return 1.0, 1.0
+
+    monkeypatch.setattr(zero_shot_module, "run", _run)
+
+    args = SimpleNamespace(
+        distributed=True,
+        horovod=False,
+        zeroshot_frequency=1,
+        epochs=1,
+        model="ViT-B-32",
+        device="cpu",
+        precision="fp32",
+        batch_size=1,
+    )
+    data = {"imagenet-val": _DataWrapper()}
+
+    results = zero_shot_module.zero_shot_eval(wrapped_model, data, epoch=1, args=args)
+
+    assert results["imagenet-zeroshot-val-top1"] == 1.0
+    assert build_models == [bare_model]
+    assert run_models == [bare_model]


### PR DESCRIPTION
Follow-up to #1134. The `model = model.module` unwrap added in that PR is nested inside the `if 'val' in data ...` branch, so `zero_shot_eval` (and the `imagenet-val` / `imagenet-v2` blocks) still run on a DDP-wrapped model on rank 0. With `if not is_master(args): return metrics` exiting rank > 0 early, any DDP reducer activity inside `zero_shot_eval` can deadlock against the barrier that #1134 added in `main.py` — the same symptom #1121 reported, shifted to the zero-shot path.

## Fix

Unwrap once at the top of `evaluate()`, right after the master guard. Every eval path then runs on the bare module.

Fixes #1152