### PR TITLE
Refactor NaFlex WebDataset pipeline around dict batches. 

### DIFF
--- a/src/open_clip/convert.py
+++ b/src/open_clip/convert.py
@@ -36,38 +36,59 @@ def load_big_vision_weights(model: CustomTextCLIP, checkpoint_path: str):
     interpolation = 'bilinear'
     antialias = False
 
-    def _convert_timm_img(module, prefix):
-        embed_conv_w = _n2p(w[f'{prefix}embedding/kernel'])
-        if embed_conv_w.shape[-2:] != module.patch_embed.proj.weight.shape[-2:]:
-            embed_conv_w = resample_patch_embed(
-                embed_conv_w,
-                module.patch_embed.proj.weight.shape[-2:],
+    def _linear_patch_embed_to_conv(embed_w, conv_weight_shape):
+        out_channels, in_channels, patch_height, patch_width = conv_weight_shape
+        if embed_w.shape != (out_channels, in_channels * patch_height * patch_width):
+            return embed_w
+        return embed_w.reshape(out_channels, patch_height, patch_width, in_channels).permute(0, 3, 1, 2)
+
+    def _reshape_grid_pos_embed(pos_embed_w, target_shape):
+        if pos_embed_w.ndim == 3:
+            pos_embed_w = pos_embed_w.unsqueeze(0)
+        if pos_embed_w.shape == target_shape:
+            return pos_embed_w
+
+        if pos_embed_w.ndim == 4 and len(target_shape) == 4:
+            old_size = pos_embed_w.shape[1:3]
+            new_size = target_shape[1:3]
+            pos_embed_w = resample_abs_pos_embed(
+                pos_embed_w.reshape(1, -1, pos_embed_w.shape[-1]),
+                new_size=new_size,
+                old_size=old_size,
+                num_prefix_tokens=0,
                 interpolation=interpolation,
                 antialias=antialias,
                 verbose=True,
             )
-        module.patch_embed.proj.weight.copy_(embed_conv_w)
-        module.patch_embed.proj.bias.copy_(_n2p(w[f'{prefix}embedding/bias']))
+            pos_embed_w = pos_embed_w.reshape(target_shape)
+        return pos_embed_w
 
-        if module.cls_token is not None:
-            module.cls_token.copy_(_n2p(w[f'{prefix}cls'], t=False))
+    def _copy_map_head(module, prefix):
+        if module.attn_pool is None:
+            return
 
-        pos_embed_w = _n2p(w[f'{prefix}pos_embedding'], t=False)
-        if pos_embed_w.shape != module.pos_embed.shape:
-            assert False, f'{pos_embed_w.shape}, {module.pos_embed.shape}'
-            num_prefix_tokens = 0 if getattr(module, 'no_embed_class', False) else getattr(module, 'num_prefix_tokens', 1)
-            pos_embed_w = resample_abs_pos_embed(  # resize pos embedding when different size from pretrained weights
-                pos_embed_w,
-                new_size=module.patch_embed.grid_size,
-                num_prefix_tokens=num_prefix_tokens,
-                interpolation=interpolation,
-                antialias=antialias,
-                verbose=True,
-            )
-        module.pos_embed.copy_(pos_embed_w)
+        block_prefix = f'{prefix}MAPHead_0/'
+        mha_prefix = block_prefix + f'MultiHeadDotProductAttention_0/'
+        module.attn_pool.latent.copy_(_n2p(w[f'{block_prefix}probe'], t=False))
+        module.attn_pool.q.weight.copy_(_n2p(w[f'{mha_prefix}query/kernel'], t=False).flatten(1).T)
+        module.attn_pool.q.bias.copy_(_n2p(w[f'{mha_prefix}query/bias'], t=False).reshape(-1))
+        module.attn_pool.kv.weight.copy_(torch.cat([
+            _n2p(w[f'{mha_prefix}{n}/kernel'], t=False).flatten(1).T for n in ('key', 'value')]))
+        module.attn_pool.kv.bias.copy_(torch.cat([
+            _n2p(w[f'{mha_prefix}{n}/bias'], t=False).reshape(-1) for n in ('key', 'value')]))
+        module.attn_pool.proj.weight.copy_(_n2p(w[f'{mha_prefix}out/kernel']).flatten(1))
+        module.attn_pool.proj.bias.copy_(_n2p(w[f'{mha_prefix}out/bias']))
+        module.attn_pool.norm.weight.copy_(_n2p(w[f'{block_prefix}LayerNorm_0/scale']))
+        module.attn_pool.norm.bias.copy_(_n2p(w[f'{block_prefix}LayerNorm_0/bias']))
+        for r in range(2):
+            getattr(module.attn_pool.mlp, f'fc{r + 1}').weight.copy_(
+                _n2p(w[f'{block_prefix}MlpBlock_0/Dense_{r}/kernel']))
+            getattr(module.attn_pool.mlp, f'fc{r + 1}').bias.copy_(
+                _n2p(w[f'{block_prefix}MlpBlock_0/Dense_{r}/bias']))
 
+    def _copy_timm_img_blocks(blocks, prefix):
         mha_sub, b_sub, ln1_sub = (0, 0, 1)
-        for i, block in enumerate(module.blocks.children()):
+        for i, block in enumerate(blocks.children()):
             if f'{prefix}Transformer/encoderblock/LayerNorm_0/scale' in w:
                 block_prefix = f'{prefix}Transformer/encoderblock/'
                 idx = i
@@ -91,26 +112,67 @@ def load_big_vision_weights(model: CustomTextCLIP, checkpoint_path: str):
                 getattr(block.mlp, f'fc{r + 1}').bias.copy_(
                     _n2p(w[f'{block_prefix}MlpBlock_{b_sub}/Dense_{r}/bias'], idx=idx))
 
+    def _convert_timm_img(module, prefix):
+        embed_conv_w = _n2p(w[f'{prefix}embedding/kernel'])
+        if embed_conv_w.ndim == 2:
+            embed_conv_w = _linear_patch_embed_to_conv(embed_conv_w, module.patch_embed.proj.weight.shape)
+        if embed_conv_w.shape[-2:] != module.patch_embed.proj.weight.shape[-2:]:
+            embed_conv_w = resample_patch_embed(
+                embed_conv_w,
+                module.patch_embed.proj.weight.shape[-2:],
+                interpolation=interpolation,
+                antialias=antialias,
+                verbose=True,
+            )
+        module.patch_embed.proj.weight.copy_(embed_conv_w)
+        module.patch_embed.proj.bias.copy_(_n2p(w[f'{prefix}embedding/bias']))
+
+        if module.cls_token is not None:
+            module.cls_token.copy_(_n2p(w[f'{prefix}cls'], t=False))
+
+        pos_embed_w = _n2p(w[f'{prefix}pos_embedding'], t=False)
+        if pos_embed_w.ndim == 3:
+            pos_embed_w = pos_embed_w.reshape(1, -1, pos_embed_w.shape[-1])
+        if pos_embed_w.shape != module.pos_embed.shape:
+            num_prefix_tokens = (
+                0 if getattr(module, 'no_embed_class', False) else getattr(module, 'num_prefix_tokens', 1)
+            )
+            pos_embed_w = resample_abs_pos_embed(  # resize pos embedding when different size from pretrained weights
+                pos_embed_w,
+                new_size=module.patch_embed.grid_size,
+                num_prefix_tokens=num_prefix_tokens,
+                interpolation=interpolation,
+                antialias=antialias,
+                verbose=True,
+            )
+        module.pos_embed.copy_(pos_embed_w)
+
+        _copy_timm_img_blocks(module.blocks, prefix)
+
         module.norm.weight.copy_(_n2p(w[f'{prefix}Transformer/encoder_norm/scale']))
         module.norm.bias.copy_(_n2p(w[f'{prefix}Transformer/encoder_norm/bias']))
 
-        if module.attn_pool is not None:
-            block_prefix = f'{prefix}MAPHead_0/'
-            mha_prefix = block_prefix + f'MultiHeadDotProductAttention_0/'
-            module.attn_pool.latent.copy_(_n2p(w[f'{block_prefix}probe'], t=False))
-            module.attn_pool.q.weight.copy_(_n2p(w[f'{mha_prefix}query/kernel'], t=False).flatten(1).T)
-            module.attn_pool.q.bias.copy_(_n2p(w[f'{mha_prefix}query/bias'], t=False).reshape(-1))
-            module.attn_pool.kv.weight.copy_(torch.cat([
-                _n2p(w[f'{mha_prefix}{n}/kernel'], t=False).flatten(1).T for n in ('key', 'value')]))
-            module.attn_pool.kv.bias.copy_(torch.cat([
-                _n2p(w[f'{mha_prefix}{n}/bias'], t=False).reshape(-1) for n in ('key', 'value')]))
-            module.attn_pool.proj.weight.copy_(_n2p(w[f'{mha_prefix}out/kernel']).flatten(1))
-            module.attn_pool.proj.bias.copy_(_n2p(w[f'{mha_prefix}out/bias']))
-            module.attn_pool.norm.weight.copy_(_n2p(w[f'{block_prefix}LayerNorm_0/scale']))
-            module.attn_pool.norm.bias.copy_(_n2p(w[f'{block_prefix}LayerNorm_0/bias']))
-            for r in range(2):
-                getattr(module.attn_pool.mlp, f'fc{r + 1}').weight.copy_(_n2p(w[f'{block_prefix}MlpBlock_0/Dense_{r}/kernel']))
-                getattr(module.attn_pool.mlp, f'fc{r + 1}').bias.copy_(_n2p(w[f'{block_prefix}MlpBlock_0/Dense_{r}/bias']))
+        _copy_map_head(module, prefix)
+
+    def _convert_naflex_timm_img(module, prefix):
+        module.embeds.proj.weight.copy_(_n2p(w[f'{prefix}embedding/kernel']))
+        if module.embeds.proj.bias is not None:
+            module.embeds.proj.bias.copy_(_n2p(w[f'{prefix}embedding/bias']))
+
+        if module.embeds.cls_token is not None and f'{prefix}cls' in w:
+            module.embeds.cls_token.copy_(_n2p(w[f'{prefix}cls'], t=False))
+        if module.embeds.pos_embed is not None:
+            pos_embed_w = _reshape_grid_pos_embed(
+                _n2p(w[f'{prefix}pos_embedding'], t=False),
+                module.embeds.pos_embed.shape,
+            )
+            module.embeds.pos_embed.copy_(pos_embed_w)
+
+        _copy_timm_img_blocks(module.blocks, prefix)
+        if hasattr(module.norm, 'weight'):
+            module.norm.weight.copy_(_n2p(w[f'{prefix}Transformer/encoder_norm/scale']))
+            module.norm.bias.copy_(_n2p(w[f'{prefix}Transformer/encoder_norm/bias']))
+        _copy_map_head(module, prefix)
 
     def _convert_openclip_transformer(module: Transformer, prefix):
         for i, block in enumerate(module.resblocks.children()):
@@ -148,7 +210,10 @@ def load_big_vision_weights(model: CustomTextCLIP, checkpoint_path: str):
             module.text_projection.bias.copy_(_n2p(w[f'{prefix}head/bias']))
 
     root_prefix = 'params/' if 'params/b' in w else ''
-    _convert_timm_img(model.visual.trunk, f'{root_prefix}img/')
+    if model.visual.trunk.__class__.__name__ == 'NaFlexVit':
+        _convert_naflex_timm_img(model.visual.trunk, f'{root_prefix}img/')
+    else:
+        _convert_timm_img(model.visual.trunk, f'{root_prefix}img/')
     _convert_openclip_txt(model.text, f'{root_prefix}txt/')
     model.logit_bias.copy_(_n2p(w[f'{root_prefix}b'])[0])
     model.logit_scale.copy_(_n2p(w[f'{root_prefix}t'])[0])

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -832,7 +832,7 @@ def create_loss(args):
     )
 
 
-def create_task(args, model, dist_model=None):
+def create_task(args, model, dist_model=None, naflex_data_config=None):
     """Create a training task wrapping model + loss.
 
     The task constructs its own loss internally from the provided args.
@@ -842,6 +842,7 @@ def create_task(args, model, dist_model=None):
         args: Training arguments (must have model, distill, siglip, etc.).
         model: The CLIP model.
         dist_model: Optional teacher model for distillation.
+        naflex_data_config: Optional resolved NaFlex data policy.
 
     Returns:
         A TrainingTask subclass instance.
@@ -850,14 +851,14 @@ def create_task(args, model, dist_model=None):
 
     shared = dict(rank=args.rank, world_size=args.world_size)
     if args.distill:
-        return DistillCLIPTask(
+        task = DistillCLIPTask(
             model, dist_model,
             local_loss=args.local_loss,
             gather_with_grad=args.gather_with_grad,
             **shared,
         )
     elif "coca" in args.model.lower():
-        return CoCaTask(
+        task = CoCaTask(
             model,
             caption_loss_weight=args.coca_caption_loss_weight,
             clip_loss_weight=args.coca_contrastive_loss_weight,
@@ -866,18 +867,21 @@ def create_task(args, model, dist_model=None):
             **shared,
         )
     elif args.siglip:
-        return SigLIPTask(
+        task = SigLIPTask(
             model,
             dist_impl=args.loss_dist_impl,
             **shared,
         )
     else:
-        return CLIPTask(
+        task = CLIPTask(
             model,
             local_loss=args.local_loss,
             gather_with_grad=args.gather_with_grad,
             **shared,
         )
+    if naflex_data_config is not None:
+        task.set_naflex_data_config(naflex_data_config)
+    return task
 
 
 def create_model_and_transforms(

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -63,6 +63,9 @@ def _rescan_model_configs():
 _rescan_model_configs()  # initial populate of model config registry
 
 
+_NAFLEX_TIMM_CONVERT_PREFIXES = ('eva', 'vit_')
+
+
 def list_models():
     """ enumerate available model architectures based on config files """
     return list(_MODEL_CONFIGS.keys())
@@ -181,6 +184,66 @@ def load_state_dict(
     return state_dict
 
 
+def _is_naflex_timm_model_name(model_name: str) -> bool:
+    return model_name.startswith('naflexvit')
+
+
+def _can_convert_timm_model_to_naflex(model_name: str) -> bool:
+    return _is_naflex_timm_model_name(model_name) or model_name.startswith(_NAFLEX_TIMM_CONVERT_PREFIXES)
+
+
+def _force_naflex_timm_vision(vision_cfg: Dict[str, Any]) -> None:
+    timm_model_name = vision_cfg.get('timm_model_name')
+    if not timm_model_name:
+        raise RuntimeError("NaFlex vision mode requires a timm vision tower.")
+    if _is_naflex_timm_model_name(timm_model_name):
+        return
+    if not _can_convert_timm_model_to_naflex(timm_model_name):
+        raise RuntimeError(
+            f"NaFlex vision mode cannot convert timm model '{timm_model_name}'. "
+            "Use a timm EVA/ViT model or an explicit naflexvit model config."
+        )
+    timm_model_kwargs = deepcopy(vision_cfg.get('timm_model_kwargs') or {})
+    timm_model_kwargs['use_naflex'] = True
+    vision_cfg['timm_model_kwargs'] = timm_model_kwargs
+
+
+def _convert_naflex_timm_state_dict(
+        model: Union[CLIP, CustomTextCLIP],
+        state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    visual = getattr(model, 'visual', None)
+    trunk = getattr(visual, 'trunk', None)
+    if trunk is None or trunk.__class__.__name__ != 'NaFlexVit':
+        return state_dict
+
+    try:
+        from timm.models.naflexvit import checkpoint_filter_fn
+    except ImportError:
+        return state_dict
+
+    prefix = 'visual.trunk.'
+    trunk_state_dict = {
+        k[len(prefix):]: v
+        for k, v in state_dict.items()
+        if k.startswith(prefix)
+    }
+    if not trunk_state_dict:
+        return state_dict
+
+    converted_trunk_state_dict = checkpoint_filter_fn(dict(trunk_state_dict), trunk)
+    converted_state_dict = {
+        k: v
+        for k, v in state_dict.items()
+        if not k.startswith(prefix)
+    }
+    converted_state_dict.update({
+        prefix + k: v
+        for k, v in converted_trunk_state_dict.items()
+    })
+    return converted_state_dict
+
+
 def load_checkpoint(
         model: Union[CLIP, CustomTextCLIP],
         checkpoint_path: str,
@@ -198,6 +261,7 @@ def load_checkpoint(
 
     # Detect & convert 3rd party state_dicts -> open_clip
     state_dict = convert_state_dict(model, state_dict)
+    state_dict = _convert_naflex_timm_state_dict(model, state_dict)
 
     # Detect old format and make compatible with new format
     if 'positional_embedding' in state_dict and not hasattr(model, 'positional_embedding'):
@@ -263,6 +327,7 @@ def create_model(
         force_image_size: Optional[Union[int, Tuple[int, int]]] = None,
         force_preprocess_cfg: Optional[Dict[str, Any]] = None,
         force_context_length: Optional[int] = None,
+        force_naflex_vision: bool = False,
         pretrained_image: bool = False, # Load default base image weights (at creation, if no CLIP weights)
         pretrained_text: bool = True,  # Load default base text weights (at creation, if no CLIP weights) - NEW
         pretrained_image_path: Optional[str] = None, # Load specific image weights from file (after creation)
@@ -299,6 +364,7 @@ def create_model(
         force_image_size: Override image size in model config.
         force_preprocess_cfg: Dict to override specific FINAL preprocessing parameters.
         force_context_length: Override context length in model config.
+        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
         pretrained_image: Load default base weights for image tower at creation if no CLIP weights loaded.
         pretrained_text: Load default base weights for text tower at creation if no CLIP weights loaded (default: True).
         pretrained_image_path: Path to load weights specifically into image tower after creation.
@@ -440,6 +506,8 @@ def create_model(
         vision_cfg["image_size"] = force_image_size
     if force_context_length is not None:
         text_cfg["context_length"] = force_context_length
+    if force_naflex_vision:
+        _force_naflex_timm_vision(vision_cfg)
 
     # Check compatibility (e.g., QuickGELU warning for tags)
     if schema is None and pretrained_cfg_for_tag:
@@ -895,6 +963,7 @@ def create_model_and_transforms(
         force_patch_dropout: Optional[float] = None,
         force_image_size: Optional[Union[int, Tuple[int, int]]] = None,
         force_context_length: Optional[int] = None,
+        force_naflex_vision: bool = False,
         image_mean: Optional[Tuple[float, ...]] = None,
         image_std: Optional[Tuple[float, ...]] = None,
         image_interpolation: Optional[str] = None,
@@ -934,6 +1003,7 @@ def create_model_and_transforms(
         force_patch_dropout: Override patch dropout value in model config.
         force_image_size: Override image size in model config.
         force_context_length: Override context length in model config.
+        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
         image_mean: Override default image normalization mean values (per channel).
         image_std: Override default image normalization std values (per channel).
         image_interpolation: Override default interpolation method for image resizing.
@@ -998,6 +1068,7 @@ def create_model_and_transforms(
         force_image_size=force_image_size,
         force_preprocess_cfg=force_preprocess_cfg,
         force_context_length=force_context_length,
+        force_naflex_vision=force_naflex_vision,
         pretrained_image=pretrained_image,
         pretrained_text=pretrained_text,
         pretrained_image_path=pretrained_image_path,
@@ -1035,6 +1106,7 @@ def create_model_from_pretrained(
         force_custom_text: bool = False,
         force_image_size: Optional[Union[int, Tuple[int, int]]] = None,
         force_context_length: Optional[int] = None,
+        force_naflex_vision: bool = False,
         image_mean: Optional[Tuple[float, ...]] = None,
         image_std: Optional[Tuple[float, ...]] = None,
         image_interpolation: Optional[str] = None,
@@ -1069,6 +1141,7 @@ def create_model_from_pretrained(
         force_custom_text: Force use of custom text encoder architecture.
         force_image_size: Override image size in model config. Useful for using models at different resolutions.
         force_context_length: Override context length in model config.
+        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
         image_mean: Override default image normalization mean values (per channel).
         image_std: Override default image normalization std values (per channel).
         image_interpolation: Override default interpolation method for image resizing ('bicubic', 'bilinear', 'nearest').
@@ -1128,6 +1201,7 @@ def create_model_from_pretrained(
         force_image_size=force_image_size,
         force_preprocess_cfg=force_preprocess_cfg,
         force_context_length=force_context_length,
+        force_naflex_vision=force_naflex_vision,
         cache_dir=cache_dir,
         require_pretrained=True,
         weights_only=weights_only,

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -19,7 +19,15 @@ from .coca_model import CoCa
 from .loss import ClipLoss, DistillClipLoss, CoCaLoss, SigLipLoss
 from .pretrained import is_pretrained_cfg, get_pretrained_cfg, download_pretrained,\
     list_pretrained_tags_by_model, download_pretrained_from_hf
-from .transform import image_transform_v2, AugmentationCfg, PreprocessCfg, merge_preprocess_dict, merge_preprocess_kwargs
+from .transform import (
+    AugmentationCfg,
+    PreprocessCfg,
+    image_transform_v2,
+    is_naflex_aug_cfg,
+    merge_preprocess_dict,
+    merge_preprocess_kwargs,
+    naflex_eval_transform_v2,
+)
 from .tokenizer import HFTokenizer, SimpleTokenizer, SigLipTokenizer, DEFAULT_CONTEXT_LENGTH
 
 HF_HUB_PREFIX = 'hf-hub:'
@@ -942,6 +950,8 @@ def create_model_and_transforms(
             - model: The created model instance
             - preprocess_train: Image preprocessing transform for training (includes augmentation)
             - preprocess_val: Image preprocessing transform for validation/inference (no augmentation)
+              When ``aug_cfg`` enables NaFlex, this is a factory that must be called with
+              ``max_seq_len`` and ``patch_size`` and returns image patch dictionaries.
 
     Example:
         >>> # Basic usage with built-in model
@@ -961,7 +971,8 @@ def create_model_and_transforms(
     Note:
         The training transform includes data augmentation based on `aug_cfg`, while the validation
         transform performs only the necessary preprocessing (resize, center crop, normalize) without
-        any random augmentation.
+        any random augmentation. NaFlex validation transforms are factory objects rather than direct
+        image callables; use the ``is_naflex_eval_transform_factory`` attribute to detect them.
     """
     force_preprocess_cfg = merge_preprocess_kwargs(
         {},
@@ -1000,10 +1011,13 @@ def create_model_and_transforms(
         is_train=True,
         aug_cfg=aug_cfg,
     )
-    preprocess_val = image_transform_v2(
-        pp_cfg,
-        is_train=False,
-    )
+    if is_naflex_aug_cfg(aug_cfg):
+        preprocess_val = naflex_eval_transform_v2(pp_cfg)
+    else:
+        preprocess_val = image_transform_v2(
+            pp_cfg,
+            is_train=False,
+        )
 
     return model, preprocess_train, preprocess_val
 

--- a/src/open_clip/factory.py
+++ b/src/open_clip/factory.py
@@ -17,6 +17,7 @@ from .model import CLIP, CustomTextCLIP, convert_weights_to_lp, convert_to_custo
     resize_pos_embed, get_cast_dtype, resize_text_pos_embed, set_model_preprocess_cfg
 from .coca_model import CoCa
 from .loss import ClipLoss, DistillClipLoss, CoCaLoss, SigLipLoss
+from .naflex_convert import apply_naflex_vision_config, convert_naflex_state_dict
 from .pretrained import is_pretrained_cfg, get_pretrained_cfg, download_pretrained,\
     list_pretrained_tags_by_model, download_pretrained_from_hf
 from .transform import (
@@ -61,9 +62,6 @@ def _rescan_model_configs():
 
 
 _rescan_model_configs()  # initial populate of model config registry
-
-
-_NAFLEX_TIMM_CONVERT_PREFIXES = ('eva', 'vit_')
 
 
 def list_models():
@@ -184,66 +182,6 @@ def load_state_dict(
     return state_dict
 
 
-def _is_naflex_timm_model_name(model_name: str) -> bool:
-    return model_name.startswith('naflexvit')
-
-
-def _can_convert_timm_model_to_naflex(model_name: str) -> bool:
-    return _is_naflex_timm_model_name(model_name) or model_name.startswith(_NAFLEX_TIMM_CONVERT_PREFIXES)
-
-
-def _force_naflex_timm_vision(vision_cfg: Dict[str, Any]) -> None:
-    timm_model_name = vision_cfg.get('timm_model_name')
-    if not timm_model_name:
-        raise RuntimeError("NaFlex vision mode requires a timm vision tower.")
-    if _is_naflex_timm_model_name(timm_model_name):
-        return
-    if not _can_convert_timm_model_to_naflex(timm_model_name):
-        raise RuntimeError(
-            f"NaFlex vision mode cannot convert timm model '{timm_model_name}'. "
-            "Use a timm EVA/ViT model or an explicit naflexvit model config."
-        )
-    timm_model_kwargs = deepcopy(vision_cfg.get('timm_model_kwargs') or {})
-    timm_model_kwargs['use_naflex'] = True
-    vision_cfg['timm_model_kwargs'] = timm_model_kwargs
-
-
-def _convert_naflex_timm_state_dict(
-        model: Union[CLIP, CustomTextCLIP],
-        state_dict: Dict[str, torch.Tensor],
-) -> Dict[str, torch.Tensor]:
-    visual = getattr(model, 'visual', None)
-    trunk = getattr(visual, 'trunk', None)
-    if trunk is None or trunk.__class__.__name__ != 'NaFlexVit':
-        return state_dict
-
-    try:
-        from timm.models.naflexvit import checkpoint_filter_fn
-    except ImportError:
-        return state_dict
-
-    prefix = 'visual.trunk.'
-    trunk_state_dict = {
-        k[len(prefix):]: v
-        for k, v in state_dict.items()
-        if k.startswith(prefix)
-    }
-    if not trunk_state_dict:
-        return state_dict
-
-    converted_trunk_state_dict = checkpoint_filter_fn(dict(trunk_state_dict), trunk)
-    converted_state_dict = {
-        k: v
-        for k, v in state_dict.items()
-        if not k.startswith(prefix)
-    }
-    converted_state_dict.update({
-        prefix + k: v
-        for k, v in converted_trunk_state_dict.items()
-    })
-    return converted_state_dict
-
-
 def load_checkpoint(
         model: Union[CLIP, CustomTextCLIP],
         checkpoint_path: str,
@@ -261,7 +199,7 @@ def load_checkpoint(
 
     # Detect & convert 3rd party state_dicts -> open_clip
     state_dict = convert_state_dict(model, state_dict)
-    state_dict = _convert_naflex_timm_state_dict(model, state_dict)
+    state_dict = convert_naflex_state_dict(model, state_dict)
 
     # Detect old format and make compatible with new format
     if 'positional_embedding' in state_dict and not hasattr(model, 'positional_embedding'):
@@ -364,7 +302,7 @@ def create_model(
         force_image_size: Override image size in model config.
         force_preprocess_cfg: Dict to override specific FINAL preprocessing parameters.
         force_context_length: Override context length in model config.
-        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
+        force_naflex_vision: Convert compatible native OpenCLIP ViT or timm EVA/ViT vision towers to NaFlexVit.
         pretrained_image: Load default base weights for image tower at creation if no CLIP weights loaded.
         pretrained_text: Load default base weights for text tower at creation if no CLIP weights loaded (default: True).
         pretrained_image_path: Path to load weights specifically into image tower after creation.
@@ -507,7 +445,7 @@ def create_model(
     if force_context_length is not None:
         text_cfg["context_length"] = force_context_length
     if force_naflex_vision:
-        _force_naflex_timm_vision(vision_cfg)
+        apply_naflex_vision_config(model_cfg)
 
     # Check compatibility (e.g., QuickGELU warning for tags)
     if schema is None and pretrained_cfg_for_tag:
@@ -1003,7 +941,7 @@ def create_model_and_transforms(
         force_patch_dropout: Override patch dropout value in model config.
         force_image_size: Override image size in model config.
         force_context_length: Override context length in model config.
-        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
+        force_naflex_vision: Convert compatible native OpenCLIP ViT or timm EVA/ViT vision towers to NaFlexVit.
         image_mean: Override default image normalization mean values (per channel).
         image_std: Override default image normalization std values (per channel).
         image_interpolation: Override default interpolation method for image resizing.
@@ -1141,7 +1079,7 @@ def create_model_from_pretrained(
         force_custom_text: Force use of custom text encoder architecture.
         force_image_size: Override image size in model config. Useful for using models at different resolutions.
         force_context_length: Override context length in model config.
-        force_naflex_vision: Convert compatible timm EVA/ViT vision towers to NaFlexVit.
+        force_naflex_vision: Convert compatible native OpenCLIP ViT or timm EVA/ViT vision towers to NaFlexVit.
         image_mean: Override default image normalization mean values (per channel).
         image_std: Override default image normalization std values (per channel).
         image_interpolation: Override default interpolation method for image resizing ('bicubic', 'bilinear', 'nearest').

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -41,6 +41,7 @@ class CLIPVisionCfg:
     mlp_ratio: float = 4.0
     patch_size: int = 16
     image_size: Union[Tuple[int, int], int] = 224
+    image_seq_len: Optional[int] = None
 
     ls_init_value: Optional[float] = None  # layer scale initial value
     patch_dropout: float = 0.  # what fraction of patches to dropout during training (0 would mean disabled and no patches dropped) - 0.5 to 0.75 recommended in the paper for optimal results
@@ -206,6 +207,9 @@ def _build_vision_tower(
             scale_attn=vision_cfg.scale_attn,
             scale_fc=vision_cfg.scale_fc,
         )
+
+    if vision_cfg.image_seq_len is not None:
+        visual.image_seq_len = int(vision_cfg.image_seq_len)
 
     return visual
 

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -71,6 +71,7 @@ class CLIPVisionCfg:
     timm_proj_bias: bool = False  # enable bias final projection
     timm_drop: float = 0.  # head dropout
     timm_drop_path: Optional[float] = None  # backbone stochastic depth
+    timm_model_kwargs: Optional[dict] = None  # additional kwargs forwarded to timm.create_model()
 
 
 @dataclass
@@ -158,6 +159,7 @@ def _build_vision_tower(
             patch_drop=vision_cfg.patch_dropout if vision_cfg.patch_dropout > 0 else None,
             embed_dim=embed_dim,
             image_size=vision_cfg.image_size,
+            model_kwargs=vision_cfg.timm_model_kwargs,
         )
     elif isinstance(vision_cfg.layers, (tuple, list)):
         vision_heads = vision_cfg.width * 32 // vision_cfg.head_width

--- a/src/open_clip/model_configs/ViT-B-16-SigLIP2-naflex.json
+++ b/src/open_clip/model_configs/ViT-B-16-SigLIP2-naflex.json
@@ -3,7 +3,8 @@
     "init_logit_bias": -10,
     "custom_text": true,
     "vision_cfg": {
-        "image_size": 256,
+        "image_size": 384,
+        "image_seq_len": 576,
         "timm_model_name": "naflexvit_base_patch16_siglip",
         "timm_model_pretrained": false,
         "timm_pool": "map",

--- a/src/open_clip/model_configs/ViT-B-16-SigLIP2-naflex.json
+++ b/src/open_clip/model_configs/ViT-B-16-SigLIP2-naflex.json
@@ -1,0 +1,32 @@
+{
+    "embed_dim": 768,
+    "init_logit_bias": -10,
+    "custom_text": true,
+    "vision_cfg": {
+        "image_size": 256,
+        "timm_model_name": "naflexvit_base_patch16_siglip",
+        "timm_model_pretrained": false,
+        "timm_pool": "map",
+        "timm_proj": "none"
+    },
+    "text_cfg": {
+        "context_length": 64,
+        "vocab_size": 256000,
+        "hf_tokenizer_name": "timm/ViT-B-16-SigLIP2-256",
+        "tokenizer_kwargs": {
+            "clean": "canonicalize"
+        },
+        "width": 768,
+        "heads": 12,
+        "layers": 12,
+        "no_causal_mask": true,
+        "proj_bias": true,
+        "pool_type": "last",
+        "norm_kwargs": {
+            "eps": 1e-6
+        },
+        "act_kwargs": {
+            "approximate": "tanh"
+        }
+    }
+}

--- a/src/open_clip/model_configs/ViT-SO400M-16-SigLIP2-naflex.json
+++ b/src/open_clip/model_configs/ViT-SO400M-16-SigLIP2-naflex.json
@@ -1,0 +1,33 @@
+{
+    "embed_dim": 1152,
+    "init_logit_bias": -10,
+    "custom_text": true,
+    "vision_cfg": {
+        "image_size": 256,
+        "timm_model_name": "naflexvit_so400m_patch16_siglip",
+        "timm_model_pretrained": false,
+        "timm_pool": "map",
+        "timm_proj": "none"
+    },
+    "text_cfg": {
+        "context_length": 64,
+        "vocab_size": 256000,
+        "hf_tokenizer_name": "timm/ViT-SO400M-16-SigLIP2-256",
+        "tokenizer_kwargs": {
+            "clean": "canonicalize"
+        },
+        "width": 1152,
+        "heads": 16,
+        "layers": 27,
+        "mlp_ratio": 3.7362,
+        "no_causal_mask": true,
+        "proj_bias": true,
+        "pool_type": "last",
+        "norm_kwargs": {
+            "eps": 1e-6
+        },
+        "act_kwargs": {
+            "approximate": "tanh"
+        }
+    }
+}

--- a/src/open_clip/model_configs/ViT-SO400M-16-SigLIP2-naflex.json
+++ b/src/open_clip/model_configs/ViT-SO400M-16-SigLIP2-naflex.json
@@ -3,7 +3,8 @@
     "init_logit_bias": -10,
     "custom_text": true,
     "vision_cfg": {
-        "image_size": 256,
+        "image_size": 384,
+        "image_seq_len": 576,
         "timm_model_name": "naflexvit_so400m_patch16_siglip",
         "timm_model_pretrained": false,
         "timm_pool": "map",

--- a/src/open_clip/model_configs/naflex_ViT-B-16.json
+++ b/src/open_clip/model_configs/naflex_ViT-B-16.json
@@ -1,0 +1,16 @@
+{
+    "embed_dim": 512,
+    "custom_text": true,
+    "vision_cfg": {
+        "image_size": 224,
+        "timm_model_name": "naflexvit_base_patch16_gap",
+        "timm_model_pretrained": false
+    },
+    "text_cfg": {
+        "context_length": 77,
+        "vocab_size": 49408,
+        "width": 512,
+        "heads": 8,
+        "layers": 12
+    }
+}

--- a/src/open_clip/model_configs/naflex_ViT-B-32.json
+++ b/src/open_clip/model_configs/naflex_ViT-B-32.json
@@ -1,0 +1,20 @@
+{
+    "embed_dim": 512,
+    "vision_cfg": {
+        "image_size": 224,
+        "image_seq_len": 49,
+        "timm_model_name": "naflexvit_base_patch16_gap",
+        "timm_model_pretrained": false,
+        "timm_model_kwargs": {
+            "patch_size": 32,
+            "pos_embed_grid_size": [7, 7]
+        }
+    },
+    "text_cfg": {
+        "context_length": 77,
+        "vocab_size": 49408,
+        "width": 512,
+        "heads": 8,
+        "layers": 12
+    }
+}

--- a/src/open_clip/naflex_config.py
+++ b/src/open_clip/naflex_config.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple, Union
+
+
+PatchSize = Union[int, Tuple[int, int]]
+
+
+def to_2tuple(value: PatchSize) -> Tuple[int, int]:
+    if isinstance(value, tuple):
+        if len(value) != 2:
+            raise ValueError("Patch size tuples must have exactly two values.")
+        return int(value[0]), int(value[1])
+    return int(value), int(value)
+
+
+@dataclass(frozen=True)
+class NaFlexDataConfig:
+    train_patch_sizes: Tuple[Tuple[int, int], ...] = ((16, 16),)
+    train_patch_size_probs: Optional[Tuple[float, ...]] = None
+    train_seq_lens: Tuple[int, ...] = (128, 256, 576, 784, 1024)
+    train_num_image_tokens: Optional[int] = None
+    max_tokens_per_batch: int = 4096 * 4
+    batch_divisor: int = 8
+    eval_patch_size: Tuple[int, int] = (16, 16)
+    eval_seq_len: int = 1024
+
+    @classmethod
+    def resolve(
+            cls,
+            patch_sizes: Optional[Sequence[PatchSize]] = None,
+            patch_size_probs: Optional[Sequence[float]] = None,
+            seq_lens: Optional[Sequence[int]] = None,
+            train_num_image_tokens: Optional[int] = None,
+            max_tokens_per_batch: int = 4096 * 4,
+            batch_divisor: int = 8,
+            eval_patch_size: Optional[PatchSize] = None,
+            eval_seq_len: Optional[int] = None,
+    ) -> 'NaFlexDataConfig':
+        patch_sizes = (16,) if patch_sizes is None else patch_sizes
+        train_patch_sizes = tuple(to_2tuple(size) for size in patch_sizes)
+        if not train_patch_sizes:
+            raise ValueError("NaFlex patch sizes must contain at least one value.")
+        if not all(size[0] > 0 and size[1] > 0 for size in train_patch_sizes):
+            raise ValueError("NaFlex patch sizes must be positive.")
+
+        seq_lens = (128, 256, 576, 784, 1024) if seq_lens is None else seq_lens
+        train_seq_lens = tuple(int(seq_len) for seq_len in seq_lens)
+        if not train_seq_lens:
+            raise ValueError("NaFlex sequence lengths must contain at least one value.")
+        if not all(seq_len > 0 for seq_len in train_seq_lens):
+            raise ValueError("NaFlex sequence lengths must be positive.")
+
+        train_patch_size_probs = None
+        if patch_size_probs is not None:
+            if len(patch_size_probs) != len(train_patch_sizes):
+                raise ValueError("NaFlex patch size probabilities must match patch sizes length.")
+            if not all(prob >= 0 for prob in patch_size_probs):
+                raise ValueError("NaFlex patch size probabilities must be non-negative.")
+            prob_sum = float(sum(patch_size_probs))
+            if prob_sum <= 0:
+                raise ValueError("NaFlex patch size probabilities must sum to a positive value.")
+            train_patch_size_probs = tuple(float(prob) / prob_sum for prob in patch_size_probs)
+
+        train_num_image_tokens = (
+            int(train_num_image_tokens) if train_num_image_tokens is not None else None
+        )
+        if train_num_image_tokens is not None and train_num_image_tokens <= 0:
+            raise ValueError("NaFlex train image token count must be positive.")
+
+        max_tokens_per_batch = int(max_tokens_per_batch)
+        if max_tokens_per_batch <= 0:
+            raise ValueError("NaFlex max image tokens per batch must be positive.")
+
+        batch_divisor = int(batch_divisor)
+        if batch_divisor <= 0:
+            raise ValueError("NaFlex batch divisor must be positive.")
+
+        eval_patch_size = to_2tuple(eval_patch_size) if eval_patch_size is not None else train_patch_sizes[0]
+        if eval_patch_size[0] <= 0 or eval_patch_size[1] <= 0:
+            raise ValueError("NaFlex eval patch size must be positive.")
+
+        eval_seq_len = int(eval_seq_len) if eval_seq_len is not None else max(train_seq_lens)
+        if eval_seq_len <= 0:
+            raise ValueError("NaFlex eval sequence length must be positive.")
+
+        return cls(
+            train_patch_sizes=train_patch_sizes,
+            train_patch_size_probs=train_patch_size_probs,
+            train_seq_lens=train_seq_lens,
+            train_num_image_tokens=train_num_image_tokens,
+            max_tokens_per_batch=max_tokens_per_batch,
+            batch_divisor=batch_divisor,
+            eval_patch_size=eval_patch_size,
+            eval_seq_len=eval_seq_len,
+        )
+
+    @property
+    def variable_patch_size(self) -> bool:
+        return len(self.train_patch_sizes) > 1
+
+    @property
+    def eval_config(self) -> Tuple[Tuple[int, int], int]:
+        return self.eval_patch_size, self.eval_seq_len

--- a/src/open_clip/naflex_convert.py
+++ b/src/open_clip/naflex_convert.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import torch
 from torch import nn
 
 
-_NAFLEX_TIMM_CONVERT_PREFIXES = ('eva', 'vit_')
+_NAFLEX_TIMM_CONVERT_MODULES = ('eva', 'vision_transformer')
 _NAFLEX_NATIVE_TIMM_MODEL_NAME = 'vit_base_patch16_clip_224'
 
 
@@ -19,8 +19,19 @@ def _is_naflex_timm_model_name(model_name: str) -> bool:
     return model_name.startswith('naflexvit')
 
 
+def _is_timm_model_in_modules(model_name: str, module_names: Tuple[str, ...]) -> bool:
+    try:
+        from timm.models import is_model_in_modules
+    except ImportError:
+        return False
+    return is_model_in_modules(model_name, module_names)
+
+
 def _can_convert_timm_model_to_naflex(model_name: str) -> bool:
-    return _is_naflex_timm_model_name(model_name) or model_name.startswith(_NAFLEX_TIMM_CONVERT_PREFIXES)
+    return (
+        _is_naflex_timm_model_name(model_name) or
+        _is_timm_model_in_modules(model_name, _NAFLEX_TIMM_CONVERT_MODULES)
+    )
 
 
 def _is_standard_native_vit_cfg(vision_cfg: Dict[str, Any]) -> bool:
@@ -120,6 +131,8 @@ def _force_naflex_timm_vision(vision_cfg: Dict[str, Any]) -> None:
         )
     timm_model_kwargs = deepcopy(vision_cfg.get('timm_model_kwargs') or {})
     timm_model_kwargs['use_naflex'] = True
+    if vision_cfg.get('timm_pool') == 'map' and _is_timm_model_in_modules(timm_model_name, ('eva',)):
+        timm_model_kwargs.setdefault('pool_include_prefix', True)
     vision_cfg['timm_model_kwargs'] = timm_model_kwargs
 
 

--- a/src/open_clip/naflex_convert.py
+++ b/src/open_clip/naflex_convert.py
@@ -1,0 +1,245 @@
+from copy import deepcopy
+from typing import Any, Dict
+
+import torch
+from torch import nn
+
+
+_NAFLEX_TIMM_CONVERT_PREFIXES = ('eva', 'vit_')
+_NAFLEX_NATIVE_TIMM_MODEL_NAME = 'vit_base_patch16_clip_224'
+
+
+def _to_2tuple(value):
+    if isinstance(value, (tuple, list)):
+        return tuple(value)
+    return value, value
+
+
+def _is_naflex_timm_model_name(model_name: str) -> bool:
+    return model_name.startswith('naflexvit')
+
+
+def _can_convert_timm_model_to_naflex(model_name: str) -> bool:
+    return _is_naflex_timm_model_name(model_name) or model_name.startswith(_NAFLEX_TIMM_CONVERT_PREFIXES)
+
+
+def _is_standard_native_vit_cfg(vision_cfg: Dict[str, Any]) -> bool:
+    if vision_cfg.get('timm_model_name') or isinstance(vision_cfg.get('layers'), (tuple, list)):
+        return False
+    if vision_cfg.get('attentional_pool', False):
+        return False
+    if vision_cfg.get('pool_type', 'tok') != 'tok':
+        return False
+    if vision_cfg.get('no_ln_pre', False) or vision_cfg.get('final_ln_after_pool', False):
+        return False
+    if vision_cfg.get('output_tokens', False):
+        return False
+    if vision_cfg.get('pos_embed_type', 'learnable') != 'learnable':
+        return False
+    unsupported_custom_block = (
+        vision_cfg.get('block_type') not in (None, 'default') or
+        vision_cfg.get('qk_norm', False) or
+        vision_cfg.get('scaled_cosine_attn', False) or
+        vision_cfg.get('scale_heads', False) or
+        vision_cfg.get('scale_attn_inner', False) or
+        vision_cfg.get('scale_attn', False) or
+        vision_cfg.get('scale_fc', False)
+    )
+    if unsupported_custom_block:
+        return False
+    if vision_cfg.get('act_kwargs') is not None or vision_cfg.get('norm_kwargs') is not None:
+        return False
+    return True
+
+
+def _force_naflex_native_vit_vision(vision_cfg: Dict[str, Any], quick_gelu: bool = False) -> None:
+    if not _is_standard_native_vit_cfg(vision_cfg):
+        raise RuntimeError(
+            "NaFlex vision mode can only convert standard native OpenCLIP/OpenAI ViT towers "
+            "or compatible timm EVA/ViT towers."
+        )
+
+    image_size = vision_cfg.get('image_size', 224)
+    patch_size = vision_cfg.get('patch_size', 16)
+    width = vision_cfg.get('width', 768)
+    head_width = vision_cfg.get('head_width', 64)
+    heads = width // head_width
+    if heads <= 0 or width % head_width != 0:
+        raise RuntimeError(
+            f"NaFlex vision mode cannot convert native ViT with width={width} and head_width={head_width}."
+        )
+
+    timm_model_kwargs = deepcopy(vision_cfg.get('timm_model_kwargs') or {})
+    timm_model_kwargs.update({
+        'img_size': image_size,
+        'use_naflex': True,
+        'patch_size': patch_size,
+        'embed_dim': width,
+        'depth': vision_cfg.get('layers', 12),
+        'num_heads': heads,
+        'mlp_ratio': vision_cfg.get('mlp_ratio', 4.0),
+        'class_token': True,
+        'reg_tokens': 0,
+        'global_pool': 'token',
+        'pool_include_prefix': False,
+        'pos_embed': 'learned',
+        'pos_embed_grid_size': tuple(s // p for s, p in zip(
+            _to_2tuple(image_size),
+            _to_2tuple(patch_size),
+        )),
+        'pre_norm': True,
+        'final_norm': True,
+        'fc_norm': False,
+        'embed_proj_type': 'linear',
+        'qkv_bias': True,
+        'proj_bias': True,
+        'act_layer': 'quick_gelu' if quick_gelu else None,
+    })
+    if vision_cfg.get('ls_init_value', None) is not None:
+        timm_model_kwargs['init_values'] = vision_cfg['ls_init_value']
+    vision_cfg.update({
+        'timm_model_name': _NAFLEX_NATIVE_TIMM_MODEL_NAME,
+        'timm_model_pretrained': False,
+        'timm_pool': 'token',
+        'timm_proj': 'linear',
+        'timm_proj_bias': False,
+        'timm_model_kwargs': timm_model_kwargs,
+    })
+
+
+def _force_naflex_timm_vision(vision_cfg: Dict[str, Any]) -> None:
+    timm_model_name = vision_cfg.get('timm_model_name')
+    if not timm_model_name:
+        raise RuntimeError("NaFlex vision mode requires a compatible timm or native ViT vision tower.")
+    if _is_naflex_timm_model_name(timm_model_name):
+        return
+    if not _can_convert_timm_model_to_naflex(timm_model_name):
+        raise RuntimeError(
+            f"NaFlex vision mode cannot convert timm model '{timm_model_name}'. "
+            "Use a timm EVA/ViT model or an explicit naflexvit model config."
+        )
+    timm_model_kwargs = deepcopy(vision_cfg.get('timm_model_kwargs') or {})
+    timm_model_kwargs['use_naflex'] = True
+    vision_cfg['timm_model_kwargs'] = timm_model_kwargs
+
+
+def apply_naflex_vision_config(model_cfg: Dict[str, Any]) -> None:
+    vision_cfg = model_cfg['vision_cfg']
+    if vision_cfg.get('timm_model_name'):
+        _force_naflex_timm_vision(vision_cfg)
+    else:
+        _force_naflex_native_vit_vision(vision_cfg, quick_gelu=model_cfg.get('quick_gelu', False))
+
+
+def _reshape_native_pos_embed_for_naflex(pos_embed: torch.Tensor) -> torch.Tensor:
+    num_patches = pos_embed.shape[0]
+    grid_size = int(num_patches ** 0.5)
+    if grid_size * grid_size != num_patches:
+        raise RuntimeError(
+            f"Cannot convert native OpenCLIP ViT positional embedding with {num_patches} patch tokens."
+        )
+    return pos_embed.reshape(1, grid_size, grid_size, pos_embed.shape[-1])
+
+
+def _convert_naflex_native_vit_state_dict(
+        state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    pos_embed = state_dict.get('visual.positional_embedding')
+    cls_embed = state_dict.get('visual.class_embedding')
+    if pos_embed is None or cls_embed is None:
+        return state_dict
+
+    converted_state_dict = {
+        k: v
+        for k, v in state_dict.items()
+        if not (
+            k.startswith('visual.conv1.') or
+            k.startswith('visual.ln_pre.') or
+            k.startswith('visual.transformer.resblocks.') or
+            k.startswith('visual.ln_post.') or
+            k in ('visual.class_embedding', 'visual.positional_embedding', 'visual.proj')
+        )
+    }
+
+    patch_pos_embed = pos_embed[1:]
+    converted_state_dict['visual.trunk.embeds.cls_token'] = (cls_embed + pos_embed[0]).reshape(1, 1, -1)
+    converted_state_dict['visual.trunk.embeds.pos_embed'] = _reshape_native_pos_embed_for_naflex(patch_pos_embed)
+    converted_state_dict['visual.trunk.embeds.proj.weight'] = state_dict['visual.conv1.weight'].permute(
+        0, 2, 3, 1).flatten(1)
+    converted_state_dict['visual.trunk.norm_pre.weight'] = state_dict['visual.ln_pre.weight']
+    converted_state_dict['visual.trunk.norm_pre.bias'] = state_dict['visual.ln_pre.bias']
+    converted_state_dict['visual.trunk.norm.weight'] = state_dict['visual.ln_post.weight']
+    converted_state_dict['visual.trunk.norm.bias'] = state_dict['visual.ln_post.bias']
+    converted_state_dict['visual.head.proj.weight'] = state_dict['visual.proj'].T
+
+    block_prefix = 'visual.transformer.resblocks.'
+    block_name_map = {
+        'ln_1.': 'norm1.',
+        'attn.in_proj_weight': 'attn.qkv.weight',
+        'attn.in_proj_bias': 'attn.qkv.bias',
+        'attn.out_proj.': 'attn.proj.',
+        'ln_2.': 'norm2.',
+        'mlp.c_fc.': 'mlp.fc1.',
+        'mlp.c_proj.': 'mlp.fc2.',
+        'ls_1.gamma': 'ls1.gamma',
+        'ls_2.gamma': 'ls2.gamma',
+    }
+    for key, value in state_dict.items():
+        if not key.startswith(block_prefix):
+            continue
+        suffix = key[len(block_prefix):]
+        block_id, _, block_key = suffix.partition('.')
+        if not block_key:
+            continue
+        for old, new in block_name_map.items():
+            if block_key.startswith(old):
+                converted_state_dict[f'visual.trunk.blocks.{block_id}.{new}{block_key[len(old):]}'] = value
+                break
+
+    return converted_state_dict
+
+
+def _convert_naflex_timm_state_dict(
+        model: nn.Module,
+        state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    visual = getattr(model, 'visual', None)
+    trunk = getattr(visual, 'trunk', None)
+    if trunk is None or trunk.__class__.__name__ != 'NaFlexVit':
+        return state_dict
+
+    if 'visual.conv1.weight' in state_dict:
+        return _convert_naflex_native_vit_state_dict(state_dict)
+
+    try:
+        from timm.models.naflexvit import checkpoint_filter_fn
+    except ImportError:
+        return state_dict
+
+    prefix = 'visual.trunk.'
+    trunk_state_dict = {
+        k[len(prefix):]: v
+        for k, v in state_dict.items()
+        if k.startswith(prefix)
+    }
+    if not trunk_state_dict:
+        return state_dict
+
+    converted_trunk_state_dict = checkpoint_filter_fn(dict(trunk_state_dict), trunk)
+    converted_state_dict = {
+        k: v
+        for k, v in state_dict.items()
+        if not k.startswith(prefix)
+    }
+    converted_state_dict.update({
+        prefix + k: v
+        for k, v in converted_trunk_state_dict.items()
+    })
+    return converted_state_dict
+
+
+def convert_naflex_state_dict(
+        model: nn.Module,
+        state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    return _convert_naflex_timm_state_dict(model, state_dict)

--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -541,6 +541,9 @@ _PRETRAINED = {
     "ViT-B-16-SigLIP2-512": dict(
         webli=_slpcfg(hf_hub='timm/ViT-B-16-SigLIP2-512/'),
     ),
+    "ViT-B-16-SigLIP2-naflex": dict(
+        webli=_slpcfg(hf_hub='timm/ViT-B-16-SigLIP2-naflex/'),
+    ),
     "ViT-L-16-SigLIP2-256": dict(
         webli=_slpcfg(hf_hub='timm/ViT-L-16-SigLIP2-256/'),
     ),
@@ -564,6 +567,9 @@ _PRETRAINED = {
     ),
     "ViT-SO400M-16-SigLIP2-512": dict(
         webli=_slpcfg(hf_hub='timm/ViT-SO400M-16-SigLIP2-512/'),
+    ),
+    "ViT-SO400M-16-SigLIP2-naflex": dict(
+        webli=_slpcfg(hf_hub='timm/ViT-SO400M-16-SigLIP2-naflex/'),
     ),
     "ViT-gopt-16-SigLIP2-256": dict(
         webli=_slpcfg(hf_hub='timm/ViT-gopt-16-SigLIP2-256/'),

--- a/src/open_clip/task/image_text_task.py
+++ b/src/open_clip/task/image_text_task.py
@@ -10,36 +10,99 @@ Future modalities (NaFlex, CLAP, MamMuT) should derive directly from
 ``TrainingTask`` and supply their own contract.
 """
 import math
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
 
+from ..naflex_config import NaFlexDataConfig
 from .base_task import TrainingTask, unwrap_model
 
 
 class ImageTextTask(TrainingTask):
     """Image + text contract shared by CLIP-family tasks."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._naflex_data_config = None
+
     @property
     def data_keys(self) -> Tuple[str, ...]:
         """Keys expected in the batch dict from the data pipeline."""
         return ("image", "text")
 
+    @property
+    def naflex_data_config(self) -> Optional[NaFlexDataConfig]:
+        return self._naflex_data_config
+
+    @property
+    def naflex_eval_config(self) -> Optional[Tuple[Tuple[int, int], int]]:
+        return self._naflex_data_config.eval_config if self._naflex_data_config is not None else None
+
+    def set_naflex_data_config(
+            self,
+            naflex_data_config: Optional[NaFlexDataConfig],
+    ) -> 'ImageTextTask':
+        """Configure NaFlex train/eval data policy shared by data loaders and dummy batches."""
+        self._naflex_data_config = naflex_data_config
+        return self
+
     def create_dummy_batch(
             self,
-            image_size,
-            context_length: int,
+            image_size=None,
+            context_length: Optional[int] = None,
             batch_size: int = 1,
             device: Optional[torch.device] = None,
             dtype: Optional[torch.dtype] = None,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> Dict[str, Any]:
         """Create a dummy batch for FSDP eval on non-rank-0 workers."""
-        if not isinstance(image_size, tuple):
-            image_size = (image_size, image_size)
+        model = unwrap_model(self.trainable_module)
+        if context_length is None:
+            context_length = model.context_length
+
+        if self._naflex_data_config is not None:
+            image = self._create_naflex_dummy_image(
+                batch_size=batch_size,
+                max_seq_len=self._naflex_data_config.eval_seq_len,
+                patch_size=self._naflex_data_config.eval_patch_size,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            if image_size is None:
+                image_size = model.visual.image_size
+            if not isinstance(image_size, tuple):
+                image_size = (image_size, image_size)
+            image = torch.zeros(batch_size, 3, *image_size, device=device, dtype=dtype)
+
         return {
-            "image": torch.zeros(batch_size, 3, *image_size, device=device, dtype=dtype),
+            "image": image,
             "text": torch.zeros(batch_size, context_length, device=device, dtype=torch.long),
+        }
+
+    @staticmethod
+    def _create_naflex_dummy_image(
+            batch_size: int,
+            max_seq_len: int,
+            patch_size: Tuple[int, int],
+            device: Optional[torch.device] = None,
+            dtype: Optional[torch.dtype] = None,
+            num_channels: int = 3,
+    ) -> Dict[str, torch.Tensor]:
+        patch_dim = patch_size[0] * patch_size[1] * num_channels
+        patches = torch.zeros(batch_size, max_seq_len, patch_dim, device=device, dtype=dtype)
+
+        width = math.ceil(math.sqrt(max_seq_len))
+        patch_idx = torch.arange(max_seq_len, device=device)
+        patch_coord = torch.stack((patch_idx // width, patch_idx % width), dim=-1).long()
+        patch_coord = patch_coord.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
+        patch_valid = torch.ones(batch_size, max_seq_len, device=device, dtype=torch.bool)
+
+        return {
+            "patches": patches,
+            "patch_coord": patch_coord,
+            "patch_valid": patch_valid,
+            "seq_len": max_seq_len,
         }
 
     def clamp_logit_scale(self, max_val: float = math.log(100)):

--- a/src/open_clip/timm_model.py
+++ b/src/open_clip/timm_model.py
@@ -38,6 +38,7 @@ class TimmModel(nn.Module):
             drop_path: Optional[float] = None,
             patch_drop: Optional[float] = None,
             pretrained: bool = False,
+            model_kwargs: Optional[dict] = None,
     ):
         super().__init__()
         if timm is None:
@@ -50,6 +51,8 @@ class TimmModel(nn.Module):
             timm_kwargs['drop_path_rate'] = drop_path
         if patch_drop is not None:
             timm_kwargs['patch_drop_rate'] = patch_drop
+        if model_kwargs:
+            timm_kwargs.update(model_kwargs)
 
         custom_pool = pool in ('abs_attn', 'rot_attn')
         if proj:

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -90,6 +90,32 @@ class NaFlexTransformFactory:
         )
 
 
+class NaFlexEvalTransformFactory:
+    is_naflex_eval_transform_factory = True
+
+    def __init__(self, **transform_kwargs) -> None:
+        self.transform_kwargs = transform_kwargs
+
+    def __call__(self, max_seq_len, patch_size):
+        from timm.data import create_transform  # timm can still be optional
+        return create_transform(
+            is_training=False,
+            naflex=True,
+            patchify=True,
+            max_seq_len=max_seq_len,
+            patch_size=patch_size,
+            **self.transform_kwargs,
+        )
+
+
+def is_naflex_aug_cfg(aug_cfg: Optional[Union[Dict[str, Any], AugmentationCfg]]) -> bool:
+    if isinstance(aug_cfg, dict):
+        return bool(aug_cfg.get("naflex", False))
+    if isinstance(aug_cfg, AugmentationCfg):
+        return bool(aug_cfg.naflex)
+    return False
+
+
 def _setup_size(size, error_msg):
     if isinstance(size, numbers.Number):
         return int(size), int(size)
@@ -480,4 +506,13 @@ def image_transform_v2(
         resize_mode=cfg.resize_mode,
         fill_color=cfg.fill_color,
         aug_cfg=aug_cfg,
+    )
+
+
+def naflex_eval_transform_v2(cfg: PreprocessCfg):
+    return NaFlexEvalTransformFactory(
+        input_size=cfg.input_size,
+        mean=cfg.mean,
+        std=cfg.std,
+        interpolation=cfg.interpolation,
     )

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -2,6 +2,7 @@ import numbers
 import random
 import warnings
 from dataclasses import dataclass, asdict
+from functools import partial
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -66,6 +67,7 @@ class AugmentationCfg:
     color_jitter: Optional[Union[float, Tuple[float, float, float], Tuple[float, float, float, float]]] = None
     re_prob: Optional[float] = None
     re_count: Optional[int] = None
+    naflex: bool = False
     use_timm: bool = False
 
     # params for simclr_jitter_gray
@@ -357,6 +359,7 @@ def image_transform(
     if is_train:
         aug_cfg_dict = {k: v for k, v in asdict(aug_cfg).items() if v is not None}
         use_timm = aug_cfg_dict.pop('use_timm', False)
+        use_naflex = aug_cfg_dict.pop('naflex', False)
         if use_timm:
             from timm.data import create_transform  # timm can still be optional
             if isinstance(image_size, (tuple, list)):
@@ -370,7 +373,7 @@ def image_transform(
             aug_cfg_dict.pop('color_jitter_prob', None)
             aug_cfg_dict.pop('gray_scale_prob', None)
 
-            train_transform = create_transform(
+            timm_transform_kwargs = dict(
                 input_size=input_size,
                 is_training=True,
                 hflip=0.,
@@ -380,7 +383,14 @@ def image_transform(
                 interpolation=interpolation,
                 **aug_cfg_dict,
             )
+            if use_naflex:
+                train_transform = partial(create_transform, naflex=True, **timm_transform_kwargs)
+                train_transform.is_naflex_transform_factory = True
+            else:
+                train_transform = create_transform(**timm_transform_kwargs)
         else:
+            if use_naflex:
+                raise ValueError("NaFlex training transforms require `use_timm=True` in `aug_cfg`.")
             train_transform = [
                 RandomResizedCrop(
                     image_size,

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -2,7 +2,6 @@ import numbers
 import random
 import warnings
 from dataclasses import dataclass, asdict
-from functools import partial
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -73,6 +72,22 @@ class AugmentationCfg:
     # params for simclr_jitter_gray
     color_jitter_prob: float = None
     gray_scale_prob: float = None
+
+
+class NaFlexTransformFactory:
+    is_naflex_transform_factory = True
+
+    def __init__(self, **transform_kwargs) -> None:
+        self.transform_kwargs = transform_kwargs
+
+    def __call__(self, max_seq_len, patch_size):
+        from timm.data import create_transform  # timm can still be optional
+        return create_transform(
+            naflex=True,
+            max_seq_len=max_seq_len,
+            patch_size=patch_size,
+            **self.transform_kwargs,
+        )
 
 
 def _setup_size(size, error_msg):
@@ -384,8 +399,7 @@ def image_transform(
                 **aug_cfg_dict,
             )
             if use_naflex:
-                train_transform = partial(create_transform, naflex=True, **timm_transform_kwargs)
-                train_transform.is_naflex_transform_factory = True
+                train_transform = NaFlexTransformFactory(**timm_transform_kwargs)
             else:
                 train_transform = create_transform(**timm_transform_kwargs)
         else:
@@ -414,7 +428,9 @@ def image_transform(
             ])
             train_transform = Compose(train_transform)
             if aug_cfg_dict:
-                warnings.warn(f'Unused augmentation cfg items, specify `use_timm` to use ({list(aug_cfg_dict.keys())}).')
+                warnings.warn(
+                    f'Unused augmentation cfg items, specify `use_timm` to use ({list(aug_cfg_dict.keys())}).'
+                )
         return train_transform
     else:
         if resize_mode == 'longest':

--- a/src/open_clip_train/data.py
+++ b/src/open_clip_train/data.py
@@ -7,6 +7,7 @@ _logger = logging.getLogger(__name__)
 import os
 import random
 import sys
+import warnings
 import braceexpand
 from dataclasses import dataclass
 from multiprocessing import Value
@@ -197,8 +198,6 @@ def group_by_keys_nothrow(data, keys=base_plus_ext, lcase=True, suffixes=None, h
     current_sample = None
     for filesample in data:
         assert isinstance(filesample, dict)
-        if "fname" not in filesample or "data" not in filesample:
-            continue
         fname, value = filesample["fname"], filesample["data"]
         prefix, suffix = keys(fname)
         if prefix is None:
@@ -332,6 +331,20 @@ class ResampledShards2(IterableDataset):
                 yield dict(url=self.rng.choices(self.urls, weights=self.weights, k=1)[0])
 
 
+class RepeatedShardList(IterableDataset):
+    """An iterable dataset that repeats a finite shard list."""
+
+    def __init__(self, urls):
+        super().__init__()
+        self.urls, _ = expand_urls(urls)
+        assert isinstance(self.urls[0], str)
+
+    def __iter__(self):
+        while True:
+            for url in self.urls:
+                yield dict(url=url)
+
+
 def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokenizer=None):
     input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
@@ -369,6 +382,8 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         require_naflex()
         if not getattr(preprocess_img, 'is_naflex_transform_factory', False):
             raise ValueError("NaFlex WebDataset training requires `--aug-cfg use_timm=True naflex=True`.")
+    elif is_train and getattr(args, 'naflex_num_train_image_tokens', None) is not None:
+        warnings.warn("`--naflex-num-train-image-tokens` is ignored unless `--use-naflex` is set.")
 
     if resampled:
         pipeline = [ResampledShards2(
@@ -377,6 +392,10 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             deterministic=True,
             epoch=shared_epoch,
         )]
+    elif use_naflex:
+        num_shards = num_shards or len(expand_urls(input_shards)[0])
+        assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
+        pipeline = [RepeatedShardList(input_shards)]
     else:
         pipeline = [wds.SimpleShardList(input_shards)]
 
@@ -441,8 +460,9 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         ])
         naflex_batcher = pipeline[-1]
         dataset = wds.DataPipeline(*pipeline)
-        num_batches = naflex_batcher.num_batches
-        num_samples = naflex_batcher.num_samples
+        num_workers = max(1, args.workers)
+        num_batches = naflex_batcher.num_batches_for_workers(num_workers)
+        num_samples = naflex_batcher.num_samples_for_workers(num_workers)
     else:
         pipeline.extend([
             wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),

--- a/src/open_clip_train/data.py
+++ b/src/open_clip_train/data.py
@@ -23,6 +23,7 @@ from torch.utils.data.distributed import DistributedSampler
 from webdataset.filters import _shuffle
 from webdataset.tariterators import base_plus_ext, url_opener, tar_file_expander, valid_sample
 
+from open_clip_train.naflex_data import NaFlexBatcher, require_naflex
 
 
 class CsvDataset(Dataset):
@@ -196,6 +197,8 @@ def group_by_keys_nothrow(data, keys=base_plus_ext, lcase=True, suffixes=None, h
     current_sample = None
     for filesample in data:
         assert isinstance(filesample, dict)
+        if "fname" not in filesample or "data" not in filesample:
+            continue
         fname, value = filesample["fname"], filesample["data"]
         prefix, suffix = keys(fname)
         if prefix is None:
@@ -333,10 +336,16 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
+    use_naflex = getattr(args, 'use_naflex', False) and is_train
 
     num_shards = None
     if is_train:
-        if args.train_num_samples is not None:
+        num_image_tokens = getattr(args, 'naflex_num_train_image_tokens', None)
+        if use_naflex and num_image_tokens is not None and args.train_num_samples is not None:
+            raise ValueError("Specify only one of `--train-num-samples` or `--naflex-num-train-image-tokens`.")
+        if use_naflex and num_image_tokens is not None:
+            num_samples = None
+        elif args.train_num_samples is not None:
             num_samples = args.train_num_samples
         else:
             num_samples, num_shards = get_dataset_size(input_shards)
@@ -346,13 +355,21 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
                     'Please specify it via `--train-num-samples` if no dataset length info is present.')
     else:
         # Eval will just exhaust the iterator if the size is not specified.
-        num_samples = args.val_num_samples or 0 
+        num_samples = args.val_num_samples or 0
 
     shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
 
     if is_train and args.train_data_upsampling_factors is not None:
-        assert resampled, "--train_data_upsampling_factors is only supported when sampling with replacement (with --dataset-resampled)."
-    
+        assert resampled, (
+            "--train_data_upsampling_factors is only supported when sampling with replacement "
+            "(with --dataset-resampled)."
+        )
+
+    if use_naflex:
+        require_naflex()
+        if not getattr(preprocess_img, 'is_naflex_transform_factory', False):
+            raise ValueError("NaFlex WebDataset training requires `--aug-cfg use_timm=True naflex=True`.")
+
     if resampled:
         pipeline = [ResampledShards2(
             input_shards,
@@ -394,13 +411,46 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         wds.select(filter_no_caption_or_no_image),
         wds.decode("pilrgb", handler=log_and_continue),
         wds.rename(image="jpg;png;jpeg;webp", text="txt", keep=False),
-        wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
-        wds.batched(args.batch_size, partial=not is_train, collation_fn=default_collate),
     ])
 
-    dataset = wds.DataPipeline(*pipeline)
+    if use_naflex:
+        naflex_patch_size = None
+        naflex_patch_size_choices = getattr(args, 'naflex_patch_sizes', None)
+        if naflex_patch_size_choices is not None and len(naflex_patch_size_choices) == 1:
+            naflex_patch_size = naflex_patch_size_choices[0]
+            naflex_patch_size_choices = None
+        pipeline.extend([
+            wds.map_dict(text=lambda text: tokenizer(text)[0]),
+            NaFlexBatcher(
+                train_num_samples=num_samples,
+                train_num_tokens=num_image_tokens,
+                patch_size=naflex_patch_size,
+                patch_size_choices=naflex_patch_size_choices,
+                patch_size_choice_probs=getattr(args, 'naflex_patch_size_probs', None),
+                seq_lens=getattr(args, 'naflex_seq_lens', None) or (128, 256, 576, 784, 1024),
+                max_tokens_per_batch=args.naflex_max_image_tokens_per_batch,
+                transform_factory=preprocess_img,
+                seed=args.seed,
+                shuffle=True,
+                distributed=args.distributed,
+                rank=args.rank,
+                world_size=args.world_size,
+                epoch=shared_epoch,
+                batch_divisor=getattr(args, 'naflex_batch_divisor', 8),
+            ),
+        ])
+        naflex_batcher = pipeline[-1]
+        dataset = wds.DataPipeline(*pipeline)
+        num_batches = naflex_batcher.num_batches
+        num_samples = naflex_batcher.num_samples
+    else:
+        pipeline.extend([
+            wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
+            wds.batched(args.batch_size, partial=not is_train, collation_fn=default_collate),
+        ])
+        dataset = wds.DataPipeline(*pipeline)
 
-    if is_train:
+    if is_train and not use_naflex:
         if not resampled:
             num_shards = num_shards or len(expand_urls(input_shards)[0])
             assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
@@ -413,7 +463,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         num_batches = num_worker_batches * num_workers
         num_samples = num_batches * global_batch_size
         dataset = dataset.with_epoch(num_worker_batches)  # each worker is iterating over this
-    else:
+    elif not is_train:
         # last batches are partial, eval is done on single (master) node
         num_batches = math.ceil(num_samples / args.batch_size)
 

--- a/src/open_clip_train/data.py
+++ b/src/open_clip_train/data.py
@@ -27,6 +27,7 @@ from webdataset.tariterators import base_plus_ext, url_opener, tar_file_expander
 
 from open_clip_train.naflex_data import (
     NaFlexBatcher,
+    NaFlexMapDatasetWrapper,
     collate_naflex_dicts,
     collate_naflex_tuples,
     create_naflex_eval_transform,
@@ -55,7 +56,9 @@ class CsvDataset(Dataset):
         return len(self.images)
 
     def __getitem__(self, idx):
-        image = self.transforms(Image.open(str(self.images.iloc[idx])))
+        image = Image.open(str(self.images.iloc[idx]))
+        if self.transforms is not None:
+            image = self.transforms(image)
         text = self.tokenize([str(self.captions.iloc[idx])])[0]
         return {"image": image, "text": text}
 
@@ -128,18 +131,18 @@ def get_dataset_size(shards):
     return total_size, num_shards
 
 
-def get_imagenet(args, preprocess_fns, split):
+def get_imagenet(args, preprocess_fns, split, naflex_data_config=None):
     assert split in ["train", "val", "v2"]
     is_train = split == "train"
     preprocess_train, preprocess_val = preprocess_fns
-    use_naflex_eval = getattr(args, 'use_naflex', False) and not is_train
+    use_naflex_eval = naflex_data_config is not None and not is_train
     collate_fn = None
 
-    if is_train and getattr(args, 'use_naflex', False):
+    if is_train and naflex_data_config is not None:
         raise ValueError("NaFlex is only wired for validation and zero-shot ImageNet loaders, not --imagenet-train.")
 
     if use_naflex_eval:
-        preprocess_val, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_val, args)
+        preprocess_val, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_val, naflex_data_config)
         collate_fn = partial(collate_naflex_tuples, max_seq_len=naflex_max_seq_len)
 
     if split == "v2":
@@ -364,16 +367,16 @@ class RepeatedShardList(IterableDataset):
                 yield dict(url=url)
 
 
-def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokenizer=None):
+def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokenizer=None, naflex_data_config=None):
     input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
-    use_naflex_train = getattr(args, 'use_naflex', False) and is_train
-    use_naflex_eval = getattr(args, 'use_naflex', False) and not is_train
+    use_naflex_train = naflex_data_config is not None and is_train
+    use_naflex_eval = naflex_data_config is not None and not is_train
 
     num_shards = None
     if is_train:
-        num_image_tokens = getattr(args, 'naflex_num_train_image_tokens', None)
+        num_image_tokens = naflex_data_config.train_num_image_tokens if use_naflex_train else None
         if use_naflex_train and num_image_tokens is not None and args.train_num_samples is not None:
             raise ValueError("Specify only one of `--train-num-samples` or `--naflex-num-train-image-tokens`.")
         if use_naflex_train and num_image_tokens is not None:
@@ -403,9 +406,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         if not getattr(preprocess_img, 'is_naflex_transform_factory', False):
             raise ValueError("NaFlex WebDataset training requires `--aug-cfg use_timm=True naflex=True`.")
     elif use_naflex_eval:
-        preprocess_img, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_img, args)
-    elif is_train and getattr(args, 'naflex_num_train_image_tokens', None) is not None:
-        warnings.warn("`--naflex-num-train-image-tokens` is ignored unless `--use-naflex` is set.")
+        preprocess_img, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_img, naflex_data_config)
 
     if resampled:
         pipeline = [ResampledShards2(
@@ -456,8 +457,8 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
 
     if use_naflex_train:
         naflex_patch_size = None
-        naflex_patch_size_choices = getattr(args, 'naflex_patch_sizes', None)
-        if naflex_patch_size_choices is not None and len(naflex_patch_size_choices) == 1:
+        naflex_patch_size_choices = naflex_data_config.train_patch_sizes
+        if not naflex_data_config.variable_patch_size:
             naflex_patch_size = naflex_patch_size_choices[0]
             naflex_patch_size_choices = None
         pipeline.extend([
@@ -467,9 +468,9 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
                 train_num_tokens=num_image_tokens,
                 patch_size=naflex_patch_size,
                 patch_size_choices=naflex_patch_size_choices,
-                patch_size_choice_probs=getattr(args, 'naflex_patch_size_probs', None),
-                seq_lens=getattr(args, 'naflex_seq_lens', None) or (128, 256, 576, 784, 1024),
-                max_tokens_per_batch=args.naflex_max_image_tokens_per_batch,
+                patch_size_choice_probs=naflex_data_config.train_patch_size_probs,
+                seq_lens=naflex_data_config.train_seq_lens,
+                max_tokens_per_batch=naflex_data_config.max_tokens_per_batch,
                 transform_factory=preprocess_img,
                 seed=args.seed,
                 shuffle=True,
@@ -477,7 +478,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
                 rank=args.rank,
                 world_size=args.world_size,
                 epoch=shared_epoch,
-                batch_divisor=getattr(args, 'naflex_batch_divisor', 8),
+                batch_divisor=naflex_data_config.batch_divisor,
             ),
         ])
         naflex_batcher = pipeline[-1]
@@ -548,17 +549,70 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     return DataInfo(dataloader=dataloader, shared_epoch=shared_epoch)
 
 
-def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None):
+def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None, naflex_data_config=None):
     input_filename = args.train_data if is_train else args.val_data
     assert input_filename
+    shared_epoch = SharedEpoch(epoch=epoch)
+    use_naflex_train = naflex_data_config is not None and is_train
+    use_naflex_eval = naflex_data_config is not None and not is_train
+    collate_fn = default_collate
+
+    if use_naflex_train:
+        require_naflex()
+        if not getattr(preprocess_fn, 'is_naflex_transform_factory', False):
+            raise ValueError("NaFlex CSV training requires `--aug-cfg use_timm=True naflex=True`.")
+        dataset_transform = None
+    elif use_naflex_eval:
+        dataset_transform, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_fn, naflex_data_config)
+        collate_fn = partial(collate_naflex_dicts, max_seq_len=naflex_max_seq_len)
+    else:
+        dataset_transform = preprocess_fn
+
     dataset = CsvDataset(
         input_filename,
-        preprocess_fn,
+        dataset_transform,
         img_key=args.csv_img_key,
         caption_key=args.csv_caption_key,
         sep=args.csv_separator,
         tokenizer=tokenizer
     )
+
+    if use_naflex_train:
+        naflex_patch_size = None
+        naflex_patch_size_choices = naflex_data_config.train_patch_sizes
+        if not naflex_data_config.variable_patch_size:
+            naflex_patch_size = naflex_patch_size_choices[0]
+            naflex_patch_size_choices = None
+        dataset = NaFlexMapDatasetWrapper(
+            dataset,
+            train_num_tokens=naflex_data_config.train_num_image_tokens,
+            patch_size=naflex_patch_size,
+            patch_size_choices=naflex_patch_size_choices,
+            patch_size_choice_probs=naflex_data_config.train_patch_size_probs,
+            seq_lens=naflex_data_config.train_seq_lens,
+            max_tokens_per_batch=naflex_data_config.max_tokens_per_batch,
+            transform_factory=preprocess_fn,
+            seed=args.seed,
+            shuffle=True,
+            distributed=args.distributed,
+            rank=args.rank,
+            world_size=args.world_size,
+            epoch=shared_epoch,
+            batch_divisor=naflex_data_config.batch_divisor,
+        )
+        dataloader = DataLoader(
+            dataset,
+            batch_size=None,
+            shuffle=False,
+            num_workers=args.workers,
+            pin_memory=True,
+            persistent_workers=args.workers > 0,
+        )
+        num_workers = max(1, args.workers)
+        dataloader.num_samples = dataset.num_samples_for_workers(num_workers)
+        dataloader.num_batches = dataset.num_batches_for_workers(num_workers)
+        return DataInfo(dataloader=dataloader, shared_epoch=shared_epoch)
+
     num_samples = len(dataset)
     sampler = DistributedSampler(dataset) if args.distributed and is_train else None
     shuffle = is_train and sampler is None
@@ -571,6 +625,7 @@ def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None):
         pin_memory=True,
         sampler=sampler,
         drop_last=is_train,
+        collate_fn=collate_fn,
     )
     dataloader.num_samples = num_samples
     dataloader.num_batches = len(dataloader)
@@ -605,7 +660,7 @@ class SyntheticDataset(Dataset):
         return {"image": image, "text": self.preprocess_txt(self.caption)}
 
 
-def get_synthetic_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None):
+def get_synthetic_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None, naflex_data_config=None):
     image_size = preprocess_fn.transforms[0].size
     dataset = SyntheticDataset(
         transform=preprocess_fn, image_size=image_size, dataset_size=args.train_num_samples, tokenizer=tokenizer)
@@ -648,22 +703,48 @@ def get_dataset_fn(data_path, dataset_type):
         raise ValueError(f"Unsupported dataset type: {dataset_type}")
     
 
-def get_data(args, preprocess_fns, epoch=0, tokenizer=None):
+def get_data(args, preprocess_fns, epoch=0, tokenizer=None, naflex_data_config=None):
     preprocess_train, preprocess_val = preprocess_fns
     data = {}
 
+    if getattr(args, 'use_naflex', False) and naflex_data_config is None:
+        raise ValueError("NaFlex data loaders require a NaFlex data config.")
+    if not getattr(args, 'use_naflex', False) and getattr(args, 'naflex_num_train_image_tokens', None) is not None:
+        warnings.warn("`--naflex-num-train-image-tokens` is ignored unless `--use-naflex` is set.")
+
     if args.train_data or args.dataset_type == "synthetic":
         data["train"] = get_dataset_fn(args.train_data, args.dataset_type)(
-            args, preprocess_train, is_train=True, epoch=epoch, tokenizer=tokenizer)
+            args,
+            preprocess_train,
+            is_train=True,
+            epoch=epoch,
+            tokenizer=tokenizer,
+            naflex_data_config=naflex_data_config,
+        )
 
     if args.val_data:
         data["val"] = get_dataset_fn(args.val_data, args.dataset_type)(
-            args, preprocess_val, is_train=False, tokenizer=tokenizer)
+            args,
+            preprocess_val,
+            is_train=False,
+            tokenizer=tokenizer,
+            naflex_data_config=naflex_data_config,
+        )
 
     if args.imagenet_val is not None:
-        data["imagenet-val"] = get_imagenet(args, preprocess_fns, "val")
+        data["imagenet-val"] = get_imagenet(
+            args,
+            preprocess_fns,
+            "val",
+            naflex_data_config=naflex_data_config,
+        )
 
     if args.imagenet_v2 is not None:
-        data["imagenet-v2"] = get_imagenet(args, preprocess_fns, "v2")
+        data["imagenet-v2"] = get_imagenet(
+            args,
+            preprocess_fns,
+            "v2",
+            naflex_data_config=naflex_data_config,
+        )
 
     return data

--- a/src/open_clip_train/data.py
+++ b/src/open_clip_train/data.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 import braceexpand
 from dataclasses import dataclass
+from functools import partial
 from multiprocessing import Value
 
 import numpy as np
@@ -24,7 +25,13 @@ from torch.utils.data.distributed import DistributedSampler
 from webdataset.filters import _shuffle
 from webdataset.tariterators import base_plus_ext, url_opener, tar_file_expander, valid_sample
 
-from open_clip_train.naflex_data import NaFlexBatcher, require_naflex
+from open_clip_train.naflex_data import (
+    NaFlexBatcher,
+    collate_naflex_dicts,
+    collate_naflex_tuples,
+    create_naflex_eval_transform,
+    require_naflex,
+)
 
 
 class CsvDataset(Dataset):
@@ -125,6 +132,15 @@ def get_imagenet(args, preprocess_fns, split):
     assert split in ["train", "val", "v2"]
     is_train = split == "train"
     preprocess_train, preprocess_val = preprocess_fns
+    use_naflex_eval = getattr(args, 'use_naflex', False) and not is_train
+    collate_fn = None
+
+    if is_train and getattr(args, 'use_naflex', False):
+        raise ValueError("NaFlex is only wired for validation and zero-shot ImageNet loaders, not --imagenet-train.")
+
+    if use_naflex_eval:
+        preprocess_val, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_val, args)
+        collate_fn = partial(collate_naflex_tuples, max_seq_len=naflex_max_seq_len)
 
     if split == "v2":
         from imagenetv2_pytorch import ImageNetV2Dataset
@@ -162,6 +178,7 @@ def get_imagenet(args, preprocess_fns, split):
         batch_size=args.batch_size,
         num_workers=args.workers,
         sampler=sampler,
+        collate_fn=collate_fn,
     )
 
     return DataInfo(dataloader=dataloader, sampler=sampler)
@@ -172,8 +189,10 @@ def count_samples(dataloader):
     n_elements, n_batches = 0, 0
     for batch in dataloader:
         n_batches += 1
-        n_elements += len(batch["image"])
-        assert len(batch["image"]) == len(batch["text"])
+        image = batch["image"]
+        image_batch_size = image["patches"].shape[0] if isinstance(image, dict) else len(image)
+        n_elements += image_batch_size
+        assert image_batch_size == len(batch["text"])
     return n_elements, n_batches
 
 
@@ -349,14 +368,15 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     input_shards = args.train_data if is_train else args.val_data
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
-    use_naflex = getattr(args, 'use_naflex', False) and is_train
+    use_naflex_train = getattr(args, 'use_naflex', False) and is_train
+    use_naflex_eval = getattr(args, 'use_naflex', False) and not is_train
 
     num_shards = None
     if is_train:
         num_image_tokens = getattr(args, 'naflex_num_train_image_tokens', None)
-        if use_naflex and num_image_tokens is not None and args.train_num_samples is not None:
+        if use_naflex_train and num_image_tokens is not None and args.train_num_samples is not None:
             raise ValueError("Specify only one of `--train-num-samples` or `--naflex-num-train-image-tokens`.")
-        if use_naflex and num_image_tokens is not None:
+        if use_naflex_train and num_image_tokens is not None:
             num_samples = None
         elif args.train_num_samples is not None:
             num_samples = args.train_num_samples
@@ -378,10 +398,12 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             "(with --dataset-resampled)."
         )
 
-    if use_naflex:
+    if use_naflex_train:
         require_naflex()
         if not getattr(preprocess_img, 'is_naflex_transform_factory', False):
             raise ValueError("NaFlex WebDataset training requires `--aug-cfg use_timm=True naflex=True`.")
+    elif use_naflex_eval:
+        preprocess_img, naflex_max_seq_len, _ = create_naflex_eval_transform(preprocess_img, args)
     elif is_train and getattr(args, 'naflex_num_train_image_tokens', None) is not None:
         warnings.warn("`--naflex-num-train-image-tokens` is ignored unless `--use-naflex` is set.")
 
@@ -392,7 +414,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
             deterministic=True,
             epoch=shared_epoch,
         )]
-    elif use_naflex:
+    elif use_naflex_train:
         num_shards = num_shards or len(expand_urls(input_shards)[0])
         assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
         pipeline = [RepeatedShardList(input_shards)]
@@ -432,7 +454,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         wds.rename(image="jpg;png;jpeg;webp", text="txt", keep=False),
     ])
 
-    if use_naflex:
+    if use_naflex_train:
         naflex_patch_size = None
         naflex_patch_size_choices = getattr(args, 'naflex_patch_sizes', None)
         if naflex_patch_size_choices is not None and len(naflex_patch_size_choices) == 1:
@@ -463,6 +485,16 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         num_workers = max(1, args.workers)
         num_batches = naflex_batcher.num_batches_for_workers(num_workers)
         num_samples = naflex_batcher.num_samples_for_workers(num_workers)
+    elif use_naflex_eval:
+        pipeline.extend([
+            wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
+            wds.batched(
+                args.batch_size,
+                partial=True,
+                collation_fn=partial(collate_naflex_dicts, max_seq_len=naflex_max_seq_len),
+            ),
+        ])
+        dataset = wds.DataPipeline(*pipeline)
     else:
         pipeline.extend([
             wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
@@ -470,7 +502,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
         ])
         dataset = wds.DataPipeline(*pipeline)
 
-    if is_train and not use_naflex:
+    if is_train and not use_naflex_train:
         if not resampled:
             num_shards = num_shards or len(expand_urls(input_shards)[0])
             assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'

--- a/src/open_clip_train/legacy_main.py
+++ b/src/open_clip_train/legacy_main.py
@@ -26,6 +26,7 @@ except ImportError:
 from open_clip import create_model_and_transforms, get_tokenizer, create_loss
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
+from open_clip_train.naflex_data import create_naflex_data_config_from_args
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -375,11 +376,13 @@ def main(args):
 
     # initialize datasets
     tokenizer = get_tokenizer(args.model, cache_dir=args.cache_dir, context_length=args.force_context_length)
+    naflex_data_config = create_naflex_data_config_from_args(args) if args.use_naflex else None
     data = get_data(
         args,
         (preprocess_train, preprocess_val),
         epoch=start_epoch,
         tokenizer=tokenizer,
+        naflex_data_config=naflex_data_config,
     )
     assert len(data), 'At least one train or eval dataset must be specified.'
 

--- a/src/open_clip_train/legacy_main.py
+++ b/src/open_clip_train/legacy_main.py
@@ -26,7 +26,11 @@ except ImportError:
 from open_clip import create_model_and_transforms, get_tokenizer, create_loss
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
-from open_clip_train.naflex_data import create_naflex_data_config_from_args, get_naflex_model_patch_size
+from open_clip_train.naflex_data import (
+    create_naflex_data_config_from_args,
+    get_naflex_model_image_seq_len,
+    get_naflex_model_patch_size,
+)
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -378,8 +382,13 @@ def main(args):
     # initialize datasets
     tokenizer = get_tokenizer(args.model, cache_dir=args.cache_dir, context_length=args.force_context_length)
     naflex_patch_size = get_naflex_model_patch_size(model) if args.use_naflex else None
+    naflex_eval_seq_len = get_naflex_model_image_seq_len(model) if args.use_naflex else None
     naflex_data_config = (
-        create_naflex_data_config_from_args(args, default_patch_size=naflex_patch_size)
+        create_naflex_data_config_from_args(
+            args,
+            default_patch_size=naflex_patch_size,
+            default_eval_seq_len=naflex_eval_seq_len,
+        )
         if args.use_naflex else None
     )
     data = get_data(

--- a/src/open_clip_train/legacy_main.py
+++ b/src/open_clip_train/legacy_main.py
@@ -26,7 +26,7 @@ except ImportError:
 from open_clip import create_model_and_transforms, get_tokenizer, create_loss
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
-from open_clip_train.naflex_data import create_naflex_data_config_from_args
+from open_clip_train.naflex_data import create_naflex_data_config_from_args, get_naflex_model_patch_size
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -227,6 +227,7 @@ def main(args):
         image_interpolation=args.image_interpolation,
         image_resize_mode=args.image_resize_mode,  # only effective for inference
         aug_cfg=args.aug_cfg,
+        force_naflex_vision=args.force_naflex_vision,
         pretrained_image=args.pretrained_image,
         output_dict=True,
         cache_dir=args.cache_dir,
@@ -376,7 +377,11 @@ def main(args):
 
     # initialize datasets
     tokenizer = get_tokenizer(args.model, cache_dir=args.cache_dir, context_length=args.force_context_length)
-    naflex_data_config = create_naflex_data_config_from_args(args) if args.use_naflex else None
+    naflex_patch_size = get_naflex_model_patch_size(model) if args.use_naflex else None
+    naflex_data_config = (
+        create_naflex_data_config_from_args(args, default_patch_size=naflex_patch_size)
+        if args.use_naflex else None
+    )
     data = get_data(
         args,
         (preprocess_train, preprocess_val),

--- a/src/open_clip_train/main.py
+++ b/src/open_clip_train/main.py
@@ -29,6 +29,7 @@ from open_clip import create_model_and_transforms, get_tokenizer, create_task
 from open_clip.task import unwrap_model, save_checkpoint, load_checkpoint, save_sharded_checkpoint, load_sharded_checkpoint
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
+from open_clip_train.naflex_data import create_naflex_data_config_from_args
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -305,8 +306,10 @@ def main(args):
                 _logger.info(f"  {name}: {val}")
                 f.write(f"{name}: {val}\n")
 
+    naflex_data_config = create_naflex_data_config_from_args(args) if args.use_naflex else None
+
     # Create task (wraps model + loss)
-    task = create_task(args, model=model, dist_model=dist_model)
+    task = create_task(args, model=model, dist_model=dist_model, naflex_data_config=naflex_data_config)
     # Keep reference to unwrapped task for checkpoint methods.
     # torch.compile wraps in OptimizedModule which shadows our state_dict() override.
     original_task = task
@@ -452,6 +455,7 @@ def main(args):
         (preprocess_train, preprocess_val),
         epoch=start_epoch,
         tokenizer=tokenizer,
+        naflex_data_config=task.naflex_data_config,
     )
     assert len(data), 'At least one train or eval dataset must be specified.'
 

--- a/src/open_clip_train/main.py
+++ b/src/open_clip_train/main.py
@@ -29,7 +29,11 @@ from open_clip import create_model_and_transforms, get_tokenizer, create_task
 from open_clip.task import unwrap_model, save_checkpoint, load_checkpoint, save_sharded_checkpoint, load_sharded_checkpoint
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
-from open_clip_train.naflex_data import create_naflex_data_config_from_args, get_naflex_model_patch_size
+from open_clip_train.naflex_data import (
+    create_naflex_data_config_from_args,
+    get_naflex_model_image_seq_len,
+    get_naflex_model_patch_size,
+)
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -308,8 +312,13 @@ def main(args):
                 f.write(f"{name}: {val}\n")
 
     naflex_patch_size = get_naflex_model_patch_size(model) if args.use_naflex else None
+    naflex_eval_seq_len = get_naflex_model_image_seq_len(model) if args.use_naflex else None
     naflex_data_config = (
-        create_naflex_data_config_from_args(args, default_patch_size=naflex_patch_size)
+        create_naflex_data_config_from_args(
+            args,
+            default_patch_size=naflex_patch_size,
+            default_eval_seq_len=naflex_eval_seq_len,
+        )
         if args.use_naflex else None
     )
 

--- a/src/open_clip_train/main.py
+++ b/src/open_clip_train/main.py
@@ -29,7 +29,7 @@ from open_clip import create_model_and_transforms, get_tokenizer, create_task
 from open_clip.task import unwrap_model, save_checkpoint, load_checkpoint, save_sharded_checkpoint, load_sharded_checkpoint
 from open_clip_train.data import get_data
 from open_clip_train.distributed import is_master, init_distributed_device, broadcast_object
-from open_clip_train.naflex_data import create_naflex_data_config_from_args
+from open_clip_train.naflex_data import create_naflex_data_config_from_args, get_naflex_model_patch_size
 from open_clip_train.logger import setup_logging
 from open_clip_train.params import parse_args
 from open_clip_train.scheduler import cosine_lr, const_lr, const_lr_cooldown
@@ -246,6 +246,7 @@ def main(args):
         image_interpolation=args.image_interpolation,
         image_resize_mode=args.image_resize_mode,  # only effective for inference
         aug_cfg=args.aug_cfg,
+        force_naflex_vision=args.force_naflex_vision,
         pretrained_image=args.pretrained_image,
         output_dict=True,
         cache_dir=args.cache_dir,
@@ -306,7 +307,11 @@ def main(args):
                 _logger.info(f"  {name}: {val}")
                 f.write(f"{name}: {val}\n")
 
-    naflex_data_config = create_naflex_data_config_from_args(args) if args.use_naflex else None
+    naflex_patch_size = get_naflex_model_patch_size(model) if args.use_naflex else None
+    naflex_data_config = (
+        create_naflex_data_config_from_args(args, default_patch_size=naflex_patch_size)
+        if args.use_naflex else None
+    )
 
     # Create task (wraps model + loss)
     task = create_task(args, model=model, dist_model=dist_model, naflex_data_config=naflex_data_config)

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -1,0 +1,306 @@
+import math
+import random
+import warnings
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import torch
+import webdataset as wds
+from torch.utils.data.dataloader import default_collate
+
+try:
+    from timm.data.naflex_dataset import calculate_naflex_batch_size
+    from timm.data.naflex_transforms import Patchify
+
+    NAFLEX_AVAILABLE = True
+except ImportError:
+    calculate_naflex_batch_size = None
+    Patchify = None
+    NAFLEX_AVAILABLE = False
+
+
+PatchSize = Union[int, Tuple[int, int]]
+Sample = Dict[str, object]
+
+
+def require_naflex() -> None:
+    if not NAFLEX_AVAILABLE:
+        raise RuntimeError(
+            "NaFlex batching requires a timm version with NaFlex data support. "
+            "Install timm>=1.0.16 or a recent timm main checkout."
+        )
+
+
+def _to_2tuple(value: PatchSize) -> Tuple[int, int]:
+    if isinstance(value, tuple):
+        if len(value) != 2:
+            raise ValueError("Patch size tuples must have exactly two values.")
+        return int(value[0]), int(value[1])
+    return int(value), int(value)
+
+
+def resolve_patch_cfg(
+        patch_size: Optional[PatchSize] = None,
+        patch_size_choices: Optional[Sequence[PatchSize]] = None,
+        patch_size_choice_probs: Optional[Sequence[float]] = None,
+) -> Tuple[List[Tuple[int, int]], List[float], bool]:
+    if patch_size is None and patch_size_choices is None:
+        patch_size = 16
+    if (patch_size is None) == (patch_size_choices is None):
+        raise ValueError("Specify exactly one of `patch_size` or `patch_size_choices`.")
+
+    if patch_size is not None:
+        return [_to_2tuple(patch_size)], [1.0], False
+
+    sizes = [_to_2tuple(size) for size in patch_size_choices]
+    if not sizes:
+        raise ValueError("`patch_size_choices` must contain at least one value.")
+    if patch_size_choice_probs is None:
+        probs = [1.0 / len(sizes)] * len(sizes)
+    else:
+        if len(patch_size_choice_probs) != len(sizes):
+            raise ValueError("`patch_size_choice_probs` must match `patch_size_choices` length.")
+        prob_sum = float(sum(patch_size_choice_probs))
+        if prob_sum <= 0:
+            raise ValueError("`patch_size_choice_probs` must sum to a positive value.")
+        probs = [float(prob) / prob_sum for prob in patch_size_choice_probs]
+    return sizes, probs, True
+
+
+def _padded_per_rank(total: int, distributed: bool, world_size: int) -> int:
+    if total <= 0:
+        raise ValueError("NaFlex schedule size must be positive.")
+    if distributed and world_size > 1:
+        return math.ceil(total / world_size)
+    return total
+
+
+class NaFlexBatcher(wds.PipelineStage):
+    """WebDataset stage that turns image/text samples into NaFlex dict batches."""
+
+    def __init__(
+            self,
+            train_num_samples: Optional[int] = None,
+            train_num_tokens: Optional[int] = None,
+            patch_size: Optional[PatchSize] = None,
+            patch_size_choices: Optional[Sequence[PatchSize]] = None,
+            patch_size_choice_probs: Optional[Sequence[float]] = None,
+            seq_lens: Sequence[int] = (128, 256, 576, 784, 1024),
+            max_tokens_per_batch: int = 4096 * 4,
+            transform_factory: Optional[Callable[..., Callable]] = None,
+            seed: int = 42,
+            shuffle: bool = True,
+            distributed: bool = False,
+            rank: int = 0,
+            world_size: int = 1,
+            epoch=-1,
+            batch_divisor: int = 8,
+            image_key: str = "image",
+            target_key: str = "text",
+    ) -> None:
+        super().__init__()
+        require_naflex()
+
+        if (train_num_samples is None) == (train_num_tokens is None):
+            raise ValueError("Specify exactly one of `train_num_samples` or `train_num_tokens` for NaFlex batching.")
+        if transform_factory is None:
+            raise ValueError("NaFlex batching requires a transform factory.")
+
+        self.seq_lens = sorted(set(int(seq_len) for seq_len in seq_lens))
+        if not self.seq_lens:
+            raise ValueError("NaFlex batching requires at least one sequence length.")
+        self.max_tokens_per_batch = int(max_tokens_per_batch)
+        if self.max_tokens_per_batch <= 0:
+            raise ValueError("`max_tokens_per_batch` must be positive.")
+        self.transform_factory = transform_factory
+        self.seed = int(seed)
+        self.shuffle = bool(shuffle)
+        self.distributed = bool(distributed)
+        self.rank = int(rank) if distributed else 0
+        self.world_size = int(world_size) if distributed else 1
+        self.epoch = epoch
+        self.batch_divisor = int(batch_divisor)
+        if self.batch_divisor <= 0:
+            raise ValueError("`batch_divisor` must be positive.")
+        self.image_key = image_key
+        self.target_key = target_key
+
+        self.patch_sizes, self.patch_size_probs, self.variable_patch_size = resolve_patch_cfg(
+            patch_size=patch_size,
+            patch_size_choices=patch_size_choices,
+            patch_size_choice_probs=patch_size_choice_probs,
+        )
+        self.transforms: Dict[Tuple[int, int], Optional[Callable]] = {}
+        self.patchifiers: List[Callable] = []
+
+        for patch_idx, patch_size_tuple in enumerate(self.patch_sizes):
+            self.patchifiers.append(
+                Patchify(
+                    patch_size=patch_size_tuple,
+                    flatten_patches=not self.variable_patch_size,
+                )
+            )
+            for seq_len in self.seq_lens:
+                self.transforms[(seq_len, patch_idx)] = transform_factory(
+                    max_seq_len=seq_len,
+                    patch_size=patch_size_tuple,
+                )
+
+        if train_num_samples is not None:
+            self._create_schedule_from_num_samples(int(train_num_samples))
+        else:
+            self._create_schedule_from_num_tokens(int(train_num_tokens))
+
+    def _next_seq_len(self, generator: torch.Generator) -> int:
+        seq_idx = torch.randint(0, len(self.seq_lens), (1,), generator=generator).item()
+        return self.seq_lens[seq_idx]
+
+    def _create_schedule_from_num_samples(self, num_samples: int) -> None:
+        samples_per_rank = _padded_per_rank(num_samples, self.distributed, self.world_size)
+        remaining_samples = samples_per_rank
+        generator = torch.Generator()
+        generator.manual_seed(self.seed)
+
+        schedule = []
+        while remaining_samples > 0:
+            seq_len = self._next_seq_len(generator)
+            batch_size = calculate_naflex_batch_size(
+                tokens_per_batch=self.max_tokens_per_batch,
+                seq_len=seq_len,
+                max_size=remaining_samples,
+                divisor=self.batch_divisor,
+                rounding="floor",
+            )
+            batch_size = min(max(1, int(batch_size)), remaining_samples)
+            schedule.append((seq_len, batch_size))
+            remaining_samples -= batch_size
+
+        self._canonical_batch_schedule = schedule
+        self._num_batches_per_rank = len(schedule)
+        self._num_samples_per_rank = sum(batch_size for _, batch_size in schedule)
+
+    def _create_schedule_from_num_tokens(self, num_tokens: int) -> None:
+        tokens_per_rank = _padded_per_rank(num_tokens, self.distributed, self.world_size)
+        remaining_tokens = tokens_per_rank
+        generator = torch.Generator()
+        generator.manual_seed(self.seed)
+
+        schedule = []
+        while remaining_tokens > 0:
+            seq_len = self._next_seq_len(generator)
+            batch_size = calculate_naflex_batch_size(
+                tokens_per_batch=min(self.max_tokens_per_batch, remaining_tokens),
+                seq_len=seq_len,
+                divisor=self.batch_divisor,
+                rounding="floor",
+            )
+            batch_size = max(1, int(batch_size))
+            schedule.append((seq_len, batch_size))
+            remaining_tokens -= batch_size * seq_len
+
+        self._canonical_batch_schedule = schedule
+        self._num_batches_per_rank = len(schedule)
+        self._num_samples_per_rank = sum(batch_size for _, batch_size in schedule)
+
+    @property
+    def num_batches(self) -> int:
+        return self._num_batches_per_rank
+
+    @property
+    def num_samples(self) -> int:
+        if self.distributed:
+            return self._num_samples_per_rank * self.world_size
+        return self._num_samples_per_rank
+
+    def __len__(self) -> int:
+        return self.num_batches
+
+    def _schedule_for_worker(self, epoch: int) -> List[Tuple[int, int]]:
+        schedule = list(self._canonical_batch_schedule)
+        if self.shuffle:
+            random.Random(self.seed + epoch).shuffle(schedule)
+
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            schedule = schedule[worker_info.id::worker_info.num_workers]
+        return schedule
+
+    def _sample_patch_idx(self, generator: torch.Generator) -> int:
+        if not self.variable_patch_size:
+            return 0
+        probs = torch.tensor(self.patch_size_probs, dtype=torch.float32)
+        return int(torch.multinomial(probs, 1, generator=generator).item())
+
+    @staticmethod
+    def _collate_images(patch_dicts: List[Dict[str, torch.Tensor]], max_seq_len: int) -> Dict[str, torch.Tensor]:
+        max_patches = max_seq_len or max(patch_dict["patches"].shape[0] for patch_dict in patch_dicts)
+        batch_size = len(patch_dicts)
+        first_patches = patch_dicts[0]["patches"]
+        patches = first_patches.new_zeros((batch_size, max_patches) + tuple(first_patches.shape[1:]))
+        first_coord = patch_dicts[0]["patch_coord"]
+        patch_coord = first_coord.new_zeros((batch_size, max_patches, 2))
+        patch_valid = torch.zeros((batch_size, max_patches), dtype=torch.bool)
+
+        for sample_idx, patch_dict in enumerate(patch_dicts):
+            num_patches = min(patch_dict["patches"].shape[0], max_patches)
+            patches[sample_idx, :num_patches] = patch_dict["patches"][:num_patches]
+            patch_coord[sample_idx, :num_patches] = patch_dict["patch_coord"][:num_patches]
+            patch_valid[sample_idx, :num_patches] = patch_dict["patch_valid"][:num_patches].bool()
+
+        return {
+            "patches": patches,
+            "patch_coord": patch_coord,
+            "patch_valid": patch_valid,
+            "seq_len": max_patches,
+        }
+
+    def _collate_batch(
+            self,
+            samples: List[Sample],
+            seq_len: int,
+            patch_idx: int,
+    ) -> Dict[str, object]:
+        transform = self.transforms[(seq_len, patch_idx)]
+        patchify = self.patchifiers[patch_idx]
+        patch_dicts = []
+        targets = []
+
+        for sample in samples:
+            image = sample[self.image_key]
+            image = transform(image) if transform is not None else image
+            patch_dict = image if isinstance(image, dict) else patchify(image)
+            patch_dicts.append(patch_dict)
+            targets.append(sample[self.target_key])
+
+        return {
+            self.image_key: self._collate_images(patch_dicts, seq_len),
+            self.target_key: default_collate(targets),
+        }
+
+    def run(self, src: Iterable[Sample]):
+        if hasattr(self.epoch, "get_value"):
+            epoch = int(self.epoch.get_value())
+        else:
+            self.epoch += 1
+            epoch = int(self.epoch)
+
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + epoch)
+        samples_iter = iter(src)
+
+        for seq_len, batch_size in self._schedule_for_worker(epoch):
+            patch_idx = self._sample_patch_idx(generator)
+            samples = []
+            for _ in range(batch_size):
+                try:
+                    sample = next(samples_iter)
+                except StopIteration:
+                    warnings.warn(
+                        f"Rank {self.rank}: reached the end of WebDataset samples while building a "
+                        f"NaFlex batch with seq_len={seq_len} and batch_size={batch_size}."
+                    )
+                    return
+                if not isinstance(sample, dict):
+                    raise TypeError("NaFlexBatcher expects dictionary samples from the data pipeline.")
+                samples.append(sample)
+            if samples:
+                yield self._collate_batch(samples, seq_len, patch_idx)

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -32,6 +32,7 @@ __all__ = [
     "collate_naflex_tuples",
     "create_naflex_data_config_from_args",
     "create_naflex_eval_transform",
+    "get_naflex_model_image_seq_len",
     "get_naflex_model_patch_size",
     "require_naflex",
     "resolve_patch_cfg",
@@ -83,20 +84,28 @@ def get_naflex_model_patch_size(model) -> Optional[Tuple[int, int]]:
     return None
 
 
+def get_naflex_model_image_seq_len(model) -> Optional[int]:
+    image_seq_len = getattr(getattr(model, 'visual', None), 'image_seq_len', None)
+    return int(image_seq_len) if image_seq_len is not None else None
+
+
 def create_naflex_data_config_from_args(
         args,
         default_patch_size: Optional[PatchSize] = None,
+        default_eval_seq_len: Optional[int] = None,
 ) -> NaFlexDataConfig:
     patch_sizes = getattr(args, 'naflex_patch_sizes', None)
     if patch_sizes is None and default_patch_size is not None:
         patch_sizes = [default_patch_size]
+    seq_lens = getattr(args, 'naflex_seq_lens', None)
     return NaFlexDataConfig.resolve(
         patch_sizes=patch_sizes,
         patch_size_probs=getattr(args, 'naflex_patch_size_probs', None),
-        seq_lens=getattr(args, 'naflex_seq_lens', None),
+        seq_lens=seq_lens,
         train_num_image_tokens=getattr(args, 'naflex_num_train_image_tokens', None),
         max_tokens_per_batch=getattr(args, 'naflex_max_image_tokens_per_batch', 4096 * 4),
         batch_divisor=getattr(args, 'naflex_batch_divisor', 8),
+        eval_seq_len=default_eval_seq_len if seq_lens is None else None,
     )
 
 

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -1,7 +1,6 @@
 import math
 import random
-import warnings
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import torch
 import webdataset as wds
@@ -19,7 +18,7 @@ except ImportError:
 
 
 PatchSize = Union[int, Tuple[int, int]]
-Sample = Dict[str, object]
+Sample = Dict[str, Any]
 
 
 def require_naflex() -> None:
@@ -43,6 +42,7 @@ def resolve_patch_cfg(
         patch_size_choices: Optional[Sequence[PatchSize]] = None,
         patch_size_choice_probs: Optional[Sequence[float]] = None,
 ) -> Tuple[List[Tuple[int, int]], List[float], bool]:
+    # Mirrors timm.data.naflex_dataset._resolve_patch_cfg without importing a private helper.
     if patch_size is None and patch_size_choices is None:
         patch_size = 16
     if (patch_size is None) == (patch_size_choices is None):
@@ -108,6 +108,8 @@ class NaFlexBatcher(wds.PipelineStage):
         self.seq_lens = sorted(set(int(seq_len) for seq_len in seq_lens))
         if not self.seq_lens:
             raise ValueError("NaFlex batching requires at least one sequence length.")
+        if not all(seq_len > 0 for seq_len in self.seq_lens):
+            raise ValueError("NaFlex sequence lengths must be positive.")
         self.max_tokens_per_batch = int(max_tokens_per_batch)
         if self.max_tokens_per_batch <= 0:
             raise ValueError("`max_tokens_per_batch` must be positive.")
@@ -214,15 +216,43 @@ class NaFlexBatcher(wds.PipelineStage):
     def __len__(self) -> int:
         return self.num_batches
 
-    def _schedule_for_worker(self, epoch: int) -> List[Tuple[int, int]]:
+    def _epoch_schedule(self, epoch: int) -> List[Tuple[int, int]]:
         schedule = list(self._canonical_batch_schedule)
         if self.shuffle:
             random.Random(self.seed + epoch).shuffle(schedule)
-
-        worker_info = torch.utils.data.get_worker_info()
-        if worker_info is not None:
-            schedule = schedule[worker_info.id::worker_info.num_workers]
         return schedule
+
+    @staticmethod
+    def _pad_schedule_for_workers(
+            schedule: List[Tuple[int, int]],
+            num_workers: int,
+    ) -> List[Tuple[int, int]]:
+        if num_workers <= 1 or not schedule:
+            return schedule
+        target_batches = math.ceil(len(schedule) / num_workers) * num_workers
+        pad_batches = target_batches - len(schedule)
+        if pad_batches > 0:
+            repeats = math.ceil(pad_batches / len(schedule))
+            schedule = schedule + (schedule * repeats)[:pad_batches]
+        return schedule
+
+    def _schedule_for_worker(self, epoch: int) -> List[Tuple[int, int]]:
+        worker_info = torch.utils.data.get_worker_info()
+        num_workers = worker_info.num_workers if worker_info is not None else 1
+        worker_id = worker_info.id if worker_info is not None else 0
+        schedule = self._pad_schedule_for_workers(self._epoch_schedule(epoch), num_workers)
+        return schedule[worker_id::num_workers]
+
+    def num_batches_for_workers(self, num_workers: int) -> int:
+        schedule = self._pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
+        return len(schedule)
+
+    def num_samples_for_workers(self, num_workers: int) -> int:
+        schedule = self._pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
+        num_samples_per_rank = sum(batch_size for _, batch_size in schedule)
+        if self.distributed:
+            return num_samples_per_rank * self.world_size
+        return num_samples_per_rank
 
     def _sample_patch_idx(self, generator: torch.Generator) -> int:
         if not self.variable_patch_size:
@@ -258,7 +288,7 @@ class NaFlexBatcher(wds.PipelineStage):
             samples: List[Sample],
             seq_len: int,
             patch_idx: int,
-    ) -> Dict[str, object]:
+    ) -> Dict[str, Any]:
         transform = self.transforms[(seq_len, patch_idx)]
         patchify = self.patchifiers[patch_idx]
         patch_dicts = []
@@ -291,14 +321,7 @@ class NaFlexBatcher(wds.PipelineStage):
             patch_idx = self._sample_patch_idx(generator)
             samples = []
             for _ in range(batch_size):
-                try:
-                    sample = next(samples_iter)
-                except StopIteration:
-                    warnings.warn(
-                        f"Rank {self.rank}: reached the end of WebDataset samples while building a "
-                        f"NaFlex batch with seq_len={seq_len} and batch_size={batch_size}."
-                    )
-                    return
+                sample = next(samples_iter)
                 if not isinstance(sample, dict):
                     raise TypeError("NaFlexBatcher expects dictionary samples from the data pipeline.")
                 samples.append(sample)

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -32,6 +32,7 @@ __all__ = [
     "collate_naflex_tuples",
     "create_naflex_data_config_from_args",
     "create_naflex_eval_transform",
+    "get_naflex_model_patch_size",
     "require_naflex",
     "resolve_patch_cfg",
 ]
@@ -74,9 +75,23 @@ def resolve_patch_cfg(
     return sizes, probs, True
 
 
-def create_naflex_data_config_from_args(args) -> NaFlexDataConfig:
+def get_naflex_model_patch_size(model) -> Optional[Tuple[int, int]]:
+    visual = getattr(model, 'visual', None)
+    trunk = getattr(visual, 'trunk', visual)
+    if trunk is not None and hasattr(trunk, 'get_patch_size'):
+        return to_2tuple(trunk.get_patch_size())
+    return None
+
+
+def create_naflex_data_config_from_args(
+        args,
+        default_patch_size: Optional[PatchSize] = None,
+) -> NaFlexDataConfig:
+    patch_sizes = getattr(args, 'naflex_patch_sizes', None)
+    if patch_sizes is None and default_patch_size is not None:
+        patch_sizes = [default_patch_size]
     return NaFlexDataConfig.resolve(
-        patch_sizes=getattr(args, 'naflex_patch_sizes', None),
+        patch_sizes=patch_sizes,
         patch_size_probs=getattr(args, 'naflex_patch_size_probs', None),
         seq_lens=getattr(args, 'naflex_seq_lens', None),
         train_num_image_tokens=getattr(args, 'naflex_num_train_image_tokens', None),

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -3,15 +3,15 @@ import random
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import torch
-import webdataset as wds
 from torch.utils.data.dataloader import default_collate
 
 try:
-    from timm.data.naflex_dataset import calculate_naflex_batch_size
+    from timm.data.naflex_dataset import NaFlexCollator, calculate_naflex_batch_size
     from timm.data.naflex_transforms import Patchify
 
     NAFLEX_AVAILABLE = True
 except ImportError:
+    NaFlexCollator = None
     calculate_naflex_batch_size = None
     Patchify = None
     NAFLEX_AVAILABLE = False
@@ -24,7 +24,7 @@ Sample = Dict[str, Any]
 def require_naflex() -> None:
     if not NAFLEX_AVAILABLE:
         raise RuntimeError(
-            "NaFlex batching requires a timm version with NaFlex data support. "
+            "NaFlex requires a timm version with NaFlex data support, including eval patchify transforms. "
             "Install timm>=1.0.16 or a recent timm main checkout."
         )
 
@@ -66,6 +66,82 @@ def resolve_patch_cfg(
     return sizes, probs, True
 
 
+def resolve_naflex_eval_config(args) -> Tuple[Tuple[int, int], int]:
+    # Eval follows timm's fixed-shape policy: use the first configured patch size
+    # and pad/crop all images to the largest configured sequence length.
+    patch_sizes = getattr(args, 'naflex_patch_sizes', None)
+    patch_size = patch_sizes[0] if patch_sizes else 16
+    patch_size = _to_2tuple(patch_size)
+    if patch_size[0] <= 0 or patch_size[1] <= 0:
+        raise ValueError("NaFlex eval patch size must be positive.")
+
+    seq_lens = getattr(args, 'naflex_seq_lens', None)
+    seq_lens = [int(seq_len) for seq_len in seq_lens] if seq_lens else [576]
+    if not all(seq_len > 0 for seq_len in seq_lens):
+        raise ValueError("NaFlex eval sequence lengths must be positive.")
+    max_seq_len = max(seq_lens)
+    return patch_size, max_seq_len
+
+
+def create_naflex_eval_transform(transform_factory, args) -> Tuple[Callable, int, Tuple[int, int]]:
+    require_naflex()
+    if not getattr(transform_factory, 'is_naflex_eval_transform_factory', False):
+        raise ValueError("NaFlex eval requires `--aug-cfg use_timm=True naflex=True`.")
+
+    patch_size, max_seq_len = resolve_naflex_eval_config(args)
+    return transform_factory(max_seq_len=max_seq_len, patch_size=patch_size), max_seq_len, patch_size
+
+
+def collate_naflex_tuples(
+        batch: List[Tuple[Dict[str, torch.Tensor], Any]],
+        max_seq_len: Optional[int] = None,
+) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
+    require_naflex()
+    return NaFlexCollator(max_seq_len=max_seq_len)(batch)
+
+
+def collate_naflex_dicts(
+        batch: List[Sample],
+        image_key: str = "image",
+        target_key: str = "text",
+        max_seq_len: Optional[int] = None,
+) -> Dict[str, Any]:
+    images, targets = collate_naflex_tuples(
+        [(sample[image_key], sample[target_key]) for sample in batch],
+        max_seq_len=max_seq_len,
+    )
+    return {
+        image_key: images,
+        target_key: targets,
+    }
+
+
+def create_naflex_dummy_image(
+        batch_size: int,
+        max_seq_len: int,
+        patch_size: PatchSize,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+        num_channels: int = 3,
+) -> Dict[str, torch.Tensor]:
+    patch_size = _to_2tuple(patch_size)
+    patch_dim = patch_size[0] * patch_size[1] * num_channels
+    patches = torch.zeros(batch_size, max_seq_len, patch_dim, device=device, dtype=dtype)
+
+    width = math.ceil(math.sqrt(max_seq_len))
+    patch_idx = torch.arange(max_seq_len, device=device)
+    patch_coord = torch.stack((patch_idx // width, patch_idx % width), dim=-1).long()
+    patch_coord = patch_coord.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
+    patch_valid = torch.ones(batch_size, max_seq_len, device=device, dtype=torch.bool)
+
+    return {
+        "patches": patches,
+        "patch_coord": patch_coord,
+        "patch_valid": patch_valid,
+        "seq_len": max_seq_len,
+    }
+
+
 def _padded_per_rank(total: int, distributed: bool, world_size: int) -> int:
     if total <= 0:
         raise ValueError("NaFlex schedule size must be positive.")
@@ -74,7 +150,7 @@ def _padded_per_rank(total: int, distributed: bool, world_size: int) -> int:
     return total
 
 
-class NaFlexBatcher(wds.PipelineStage):
+class NaFlexBatcher:
     """WebDataset stage that turns image/text samples into NaFlex dict batches."""
 
     def __init__(
@@ -97,7 +173,6 @@ class NaFlexBatcher(wds.PipelineStage):
             image_key: str = "image",
             target_key: str = "text",
     ) -> None:
-        super().__init__()
         require_naflex()
 
         if (train_num_samples is None) == (train_num_tokens is None):
@@ -151,6 +226,9 @@ class NaFlexBatcher(wds.PipelineStage):
             self._create_schedule_from_num_samples(int(train_num_samples))
         else:
             self._create_schedule_from_num_tokens(int(train_num_tokens))
+
+    def __call__(self, src: Iterable[Sample]):
+        return self.run(src)
 
     def _next_seq_len(self, generator: torch.Generator) -> int:
         seq_idx = torch.randint(0, len(self.seq_lens), (1,), generator=generator).item()

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -1,9 +1,12 @@
 import math
 import random
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import torch
+from torch.utils.data import Dataset, IterableDataset
 from torch.utils.data.dataloader import default_collate
+
+from open_clip.naflex_config import NaFlexDataConfig, PatchSize, to_2tuple
 
 try:
     from timm.data.naflex_dataset import NaFlexCollator, calculate_naflex_batch_size
@@ -17,8 +20,21 @@ except ImportError:
     NAFLEX_AVAILABLE = False
 
 
-PatchSize = Union[int, Tuple[int, int]]
 Sample = Dict[str, Any]
+
+
+__all__ = [
+    "NAFLEX_AVAILABLE",
+    "NaFlexBatchScheduler",
+    "NaFlexBatcher",
+    "NaFlexMapDatasetWrapper",
+    "collate_naflex_dicts",
+    "collate_naflex_tuples",
+    "create_naflex_data_config_from_args",
+    "create_naflex_eval_transform",
+    "require_naflex",
+    "resolve_patch_cfg",
+]
 
 
 def require_naflex() -> None:
@@ -27,14 +43,6 @@ def require_naflex() -> None:
             "NaFlex requires a timm version with NaFlex data support, including eval patchify transforms. "
             "Install timm>=1.0.16 or a recent timm main checkout."
         )
-
-
-def _to_2tuple(value: PatchSize) -> Tuple[int, int]:
-    if isinstance(value, tuple):
-        if len(value) != 2:
-            raise ValueError("Patch size tuples must have exactly two values.")
-        return int(value[0]), int(value[1])
-    return int(value), int(value)
 
 
 def resolve_patch_cfg(
@@ -49,9 +57,9 @@ def resolve_patch_cfg(
         raise ValueError("Specify exactly one of `patch_size` or `patch_size_choices`.")
 
     if patch_size is not None:
-        return [_to_2tuple(patch_size)], [1.0], False
+        return [to_2tuple(patch_size)], [1.0], False
 
-    sizes = [_to_2tuple(size) for size in patch_size_choices]
+    sizes = [to_2tuple(size) for size in patch_size_choices]
     if not sizes:
         raise ValueError("`patch_size_choices` must contain at least one value.")
     if patch_size_choice_probs is None:
@@ -66,29 +74,26 @@ def resolve_patch_cfg(
     return sizes, probs, True
 
 
-def resolve_naflex_eval_config(args) -> Tuple[Tuple[int, int], int]:
-    # Eval follows timm's fixed-shape policy: use the first configured patch size
-    # and pad/crop all images to the largest configured sequence length.
-    patch_sizes = getattr(args, 'naflex_patch_sizes', None)
-    patch_size = patch_sizes[0] if patch_sizes else 16
-    patch_size = _to_2tuple(patch_size)
-    if patch_size[0] <= 0 or patch_size[1] <= 0:
-        raise ValueError("NaFlex eval patch size must be positive.")
-
-    seq_lens = getattr(args, 'naflex_seq_lens', None)
-    seq_lens = [int(seq_len) for seq_len in seq_lens] if seq_lens else [576]
-    if not all(seq_len > 0 for seq_len in seq_lens):
-        raise ValueError("NaFlex eval sequence lengths must be positive.")
-    max_seq_len = max(seq_lens)
-    return patch_size, max_seq_len
+def create_naflex_data_config_from_args(args) -> NaFlexDataConfig:
+    return NaFlexDataConfig.resolve(
+        patch_sizes=getattr(args, 'naflex_patch_sizes', None),
+        patch_size_probs=getattr(args, 'naflex_patch_size_probs', None),
+        seq_lens=getattr(args, 'naflex_seq_lens', None),
+        train_num_image_tokens=getattr(args, 'naflex_num_train_image_tokens', None),
+        max_tokens_per_batch=getattr(args, 'naflex_max_image_tokens_per_batch', 4096 * 4),
+        batch_divisor=getattr(args, 'naflex_batch_divisor', 8),
+    )
 
 
-def create_naflex_eval_transform(transform_factory, args) -> Tuple[Callable, int, Tuple[int, int]]:
+def create_naflex_eval_transform(
+        transform_factory,
+        naflex_data_config: NaFlexDataConfig,
+) -> Tuple[Callable, int, Tuple[int, int]]:
     require_naflex()
     if not getattr(transform_factory, 'is_naflex_eval_transform_factory', False):
         raise ValueError("NaFlex eval requires `--aug-cfg use_timm=True naflex=True`.")
 
-    patch_size, max_seq_len = resolve_naflex_eval_config(args)
+    patch_size, max_seq_len = naflex_data_config.eval_config
     return transform_factory(max_seq_len=max_seq_len, patch_size=patch_size), max_seq_len, patch_size
 
 
@@ -116,32 +121,6 @@ def collate_naflex_dicts(
     }
 
 
-def create_naflex_dummy_image(
-        batch_size: int,
-        max_seq_len: int,
-        patch_size: PatchSize,
-        device: Optional[torch.device] = None,
-        dtype: Optional[torch.dtype] = None,
-        num_channels: int = 3,
-) -> Dict[str, torch.Tensor]:
-    patch_size = _to_2tuple(patch_size)
-    patch_dim = patch_size[0] * patch_size[1] * num_channels
-    patches = torch.zeros(batch_size, max_seq_len, patch_dim, device=device, dtype=dtype)
-
-    width = math.ceil(math.sqrt(max_seq_len))
-    patch_idx = torch.arange(max_seq_len, device=device)
-    patch_coord = torch.stack((patch_idx // width, patch_idx % width), dim=-1).long()
-    patch_coord = patch_coord.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
-    patch_valid = torch.ones(batch_size, max_seq_len, device=device, dtype=torch.bool)
-
-    return {
-        "patches": patches,
-        "patch_coord": patch_coord,
-        "patch_valid": patch_valid,
-        "seq_len": max_seq_len,
-    }
-
-
 def _padded_per_rank(total: int, distributed: bool, world_size: int) -> int:
     if total <= 0:
         raise ValueError("NaFlex schedule size must be positive.")
@@ -150,8 +129,8 @@ def _padded_per_rank(total: int, distributed: bool, world_size: int) -> int:
     return total
 
 
-class NaFlexBatcher:
-    """WebDataset stage that turns image/text samples into NaFlex dict batches."""
+class NaFlexBatchScheduler:
+    """Shared NaFlex schedule, patchify, and collation logic."""
 
     def __init__(
             self,
@@ -168,7 +147,6 @@ class NaFlexBatcher:
             distributed: bool = False,
             rank: int = 0,
             world_size: int = 1,
-            epoch=-1,
             batch_divisor: int = 8,
             image_key: str = "image",
             target_key: str = "text",
@@ -194,7 +172,6 @@ class NaFlexBatcher:
         self.distributed = bool(distributed)
         self.rank = int(rank) if distributed else 0
         self.world_size = int(world_size) if distributed else 1
-        self.epoch = epoch
         self.batch_divisor = int(batch_divisor)
         if self.batch_divisor <= 0:
             raise ValueError("`batch_divisor` must be positive.")
@@ -226,9 +203,6 @@ class NaFlexBatcher:
             self._create_schedule_from_num_samples(int(train_num_samples))
         else:
             self._create_schedule_from_num_tokens(int(train_num_tokens))
-
-    def __call__(self, src: Iterable[Sample]):
-        return self.run(src)
 
     def _next_seq_len(self, generator: torch.Generator) -> int:
         seq_idx = torch.randint(0, len(self.seq_lens), (1,), generator=generator).item()
@@ -294,14 +268,15 @@ class NaFlexBatcher:
     def __len__(self) -> int:
         return self.num_batches
 
-    def _epoch_schedule(self, epoch: int) -> List[Tuple[int, int]]:
+    def epoch_schedule(self, epoch: int, num_workers: int = 1) -> List[Tuple[int, int]]:
         schedule = list(self._canonical_batch_schedule)
         if self.shuffle:
             random.Random(self.seed + epoch).shuffle(schedule)
+        schedule = self.pad_schedule_for_workers(schedule, max(1, num_workers))
         return schedule
 
     @staticmethod
-    def _pad_schedule_for_workers(
+    def pad_schedule_for_workers(
             schedule: List[Tuple[int, int]],
             num_workers: int,
     ) -> List[Tuple[int, int]]:
@@ -314,25 +289,25 @@ class NaFlexBatcher:
             schedule = schedule + (schedule * repeats)[:pad_batches]
         return schedule
 
-    def _schedule_for_worker(self, epoch: int) -> List[Tuple[int, int]]:
+    def worker_schedule(self, epoch: int) -> List[Tuple[int, int]]:
         worker_info = torch.utils.data.get_worker_info()
         num_workers = worker_info.num_workers if worker_info is not None else 1
         worker_id = worker_info.id if worker_info is not None else 0
-        schedule = self._pad_schedule_for_workers(self._epoch_schedule(epoch), num_workers)
+        schedule = self.epoch_schedule(epoch, num_workers=num_workers)
         return schedule[worker_id::num_workers]
 
     def num_batches_for_workers(self, num_workers: int) -> int:
-        schedule = self._pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
+        schedule = self.pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
         return len(schedule)
 
     def num_samples_for_workers(self, num_workers: int) -> int:
-        schedule = self._pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
+        schedule = self.pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
         num_samples_per_rank = sum(batch_size for _, batch_size in schedule)
         if self.distributed:
             return num_samples_per_rank * self.world_size
         return num_samples_per_rank
 
-    def _sample_patch_idx(self, generator: torch.Generator) -> int:
+    def sample_patch_idx(self, generator: torch.Generator) -> int:
         if not self.variable_patch_size:
             return 0
         probs = torch.tensor(self.patch_size_probs, dtype=torch.float32)
@@ -361,7 +336,7 @@ class NaFlexBatcher:
             "seq_len": max_patches,
         }
 
-    def _collate_batch(
+    def collate_batch(
             self,
             samples: List[Sample],
             seq_len: int,
@@ -384,19 +359,84 @@ class NaFlexBatcher:
             self.target_key: default_collate(targets),
         }
 
-    def run(self, src: Iterable[Sample]):
-        if hasattr(self.epoch, "get_value"):
-            epoch = int(self.epoch.get_value())
-        else:
-            self.epoch += 1
-            epoch = int(self.epoch)
 
+class NaFlexBatcher:
+    """WebDataset stage that turns image/text samples into NaFlex dict batches."""
+
+    def __init__(
+            self,
+            train_num_samples: Optional[int] = None,
+            train_num_tokens: Optional[int] = None,
+            patch_size: Optional[PatchSize] = None,
+            patch_size_choices: Optional[Sequence[PatchSize]] = None,
+            patch_size_choice_probs: Optional[Sequence[float]] = None,
+            seq_lens: Sequence[int] = (128, 256, 576, 784, 1024),
+            max_tokens_per_batch: int = 4096 * 4,
+            transform_factory: Optional[Callable[..., Callable]] = None,
+            seed: int = 42,
+            shuffle: bool = True,
+            distributed: bool = False,
+            rank: int = 0,
+            world_size: int = 1,
+            epoch=-1,
+            batch_divisor: int = 8,
+            image_key: str = "image",
+            target_key: str = "text",
+    ) -> None:
+        self.epoch = epoch
+        self.scheduler = NaFlexBatchScheduler(
+            train_num_samples=train_num_samples,
+            train_num_tokens=train_num_tokens,
+            patch_size=patch_size,
+            patch_size_choices=patch_size_choices,
+            patch_size_choice_probs=patch_size_choice_probs,
+            seq_lens=seq_lens,
+            max_tokens_per_batch=max_tokens_per_batch,
+            transform_factory=transform_factory,
+            seed=seed,
+            shuffle=shuffle,
+            distributed=distributed,
+            rank=rank,
+            world_size=world_size,
+            batch_divisor=batch_divisor,
+            image_key=image_key,
+            target_key=target_key,
+        )
+
+    @property
+    def num_batches(self) -> int:
+        return self.scheduler.num_batches
+
+    @property
+    def num_samples(self) -> int:
+        return self.scheduler.num_samples
+
+    def __len__(self) -> int:
+        return self.num_batches
+
+    def __call__(self, src: Iterable[Sample]):
+        return self.run(src)
+
+    def num_batches_for_workers(self, num_workers: int) -> int:
+        return self.scheduler.num_batches_for_workers(num_workers)
+
+    def num_samples_for_workers(self, num_workers: int) -> int:
+        return self.scheduler.num_samples_for_workers(num_workers)
+
+    def _epoch(self) -> int:
+        if hasattr(self.epoch, "get_value"):
+            return int(self.epoch.get_value())
+        self.epoch += 1
+        return int(self.epoch)
+
+    def run(self, src: Iterable[Sample]):
+        epoch = self._epoch()
         generator = torch.Generator()
-        generator.manual_seed(self.seed + epoch)
+        generator.manual_seed(self.scheduler.seed + epoch)
         samples_iter = iter(src)
 
-        for seq_len, batch_size in self._schedule_for_worker(epoch):
-            patch_idx = self._sample_patch_idx(generator)
+        for seq_len, batch_size in self.scheduler.worker_schedule(epoch):
+            patch_idx = self.scheduler.sample_patch_idx(generator)
             samples = []
             for _ in range(batch_size):
                 sample = next(samples_iter)
@@ -404,4 +444,114 @@ class NaFlexBatcher:
                     raise TypeError("NaFlexBatcher expects dictionary samples from the data pipeline.")
                 samples.append(sample)
             if samples:
-                yield self._collate_batch(samples, seq_len, patch_idx)
+                yield self.scheduler.collate_batch(samples, seq_len, patch_idx)
+
+
+class NaFlexMapDatasetWrapper(IterableDataset):
+    """Map-style dataset wrapper that yields NaFlex dict batches."""
+
+    def __init__(
+            self,
+            base_dataset: Dataset,
+            train_num_tokens: Optional[int] = None,
+            patch_size: Optional[PatchSize] = None,
+            patch_size_choices: Optional[Sequence[PatchSize]] = None,
+            patch_size_choice_probs: Optional[Sequence[float]] = None,
+            seq_lens: Sequence[int] = (128, 256, 576, 784, 1024),
+            max_tokens_per_batch: int = 4096 * 4,
+            transform_factory: Optional[Callable[..., Callable]] = None,
+            seed: int = 42,
+            shuffle: bool = True,
+            distributed: bool = False,
+            rank: int = 0,
+            world_size: int = 1,
+            epoch=-1,
+            batch_divisor: int = 8,
+    ) -> None:
+        if not hasattr(base_dataset, '__len__') or not hasattr(base_dataset, '__getitem__'):
+            raise TypeError("NaFlex map batching requires a map-style dataset.")
+
+        self.base_dataset = base_dataset
+        self.seed = int(seed)
+        self.shuffle = bool(shuffle)
+        self.distributed = bool(distributed)
+        self.rank = int(rank) if distributed else 0
+        self.world_size = int(world_size) if distributed else 1
+        self.epoch = epoch
+
+        train_num_samples = None if train_num_tokens is not None else len(base_dataset)
+        self.scheduler = NaFlexBatchScheduler(
+            train_num_samples=train_num_samples,
+            train_num_tokens=train_num_tokens,
+            patch_size=patch_size,
+            patch_size_choices=patch_size_choices,
+            patch_size_choice_probs=patch_size_choice_probs,
+            seq_lens=seq_lens,
+            max_tokens_per_batch=max_tokens_per_batch,
+            transform_factory=transform_factory,
+            seed=seed,
+            shuffle=shuffle,
+            distributed=distributed,
+            rank=rank,
+            world_size=world_size,
+            batch_divisor=batch_divisor,
+        )
+
+    def __len__(self) -> int:
+        return self.scheduler.num_batches
+
+    def num_batches_for_workers(self, num_workers: int) -> int:
+        return self.scheduler.num_batches_for_workers(num_workers)
+
+    def num_samples_for_workers(self, num_workers: int) -> int:
+        return self.scheduler.num_samples_for_workers(num_workers)
+
+    def _epoch(self) -> int:
+        if hasattr(self.epoch, "get_value"):
+            return int(self.epoch.get_value())
+        self.epoch += 1
+        return int(self.epoch)
+
+    def _epoch_indices(self, epoch: int, samples_per_rank: int) -> List[int]:
+        dataset_len = len(self.base_dataset)
+        if dataset_len <= 0:
+            raise ValueError("NaFlex map batching requires at least one sample.")
+
+        total_samples = samples_per_rank * self.world_size if self.distributed else samples_per_rank
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + epoch)
+        indices = []
+        while len(indices) < total_samples:
+            if self.shuffle:
+                indices.extend(torch.randperm(dataset_len, generator=generator).tolist())
+            else:
+                indices.extend(range(dataset_len))
+        indices = indices[:total_samples]
+
+        if self.distributed:
+            return indices[self.rank::self.world_size]
+        return indices
+
+    def __iter__(self):
+        epoch = self._epoch()
+        worker_info = torch.utils.data.get_worker_info()
+        num_workers = worker_info.num_workers if worker_info is not None else 1
+        worker_id = worker_info.id if worker_info is not None else 0
+
+        schedule = self.scheduler.epoch_schedule(epoch, num_workers=num_workers)
+        samples_per_rank = sum(batch_size for _, batch_size in schedule)
+        rank_indices = self._epoch_indices(epoch, samples_per_rank)
+
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + epoch)
+
+        index_offset = 0
+        for batch_idx, (seq_len, batch_size) in enumerate(schedule):
+            batch_indices = rank_indices[index_offset:index_offset + batch_size]
+            index_offset += batch_size
+            if batch_idx % num_workers != worker_id:
+                continue
+
+            patch_idx = self.scheduler.sample_patch_idx(generator)
+            samples = [self.base_dataset[idx] for idx in batch_indices]
+            yield self.scheduler.collate_batch(samples, seq_len, patch_idx)

--- a/src/open_clip_train/params.py
+++ b/src/open_clip_train/params.py
@@ -545,6 +545,16 @@ def parse_args(args):
         default=8,
         help="Divisibility constraint for scheduled NaFlex batch sizes."
     )
+    parser.add_argument(
+        "--naflex-loss-scale",
+        type=str,
+        choices=("none", "linear", "sqrt"),
+        default="none",
+        help=(
+            "Scale NaFlex training loss by actual local batch size relative to --batch-size. "
+            "Defaults to no scaling."
+        ),
+    )
 
     args = parser.parse_args(args)
     if args.use_naflex:

--- a/src/open_clip_train/params.py
+++ b/src/open_clip_train/params.py
@@ -492,7 +492,7 @@ def parse_args(args):
         "--use-naflex",
         default=False,
         action="store_true",
-        help="Use NaFlex WebDataset batching for training."
+        help="Use NaFlex WebDataset batching for training and NaFlex patchified validation / zero-shot loaders."
     )
     parser.add_argument(
         "--naflex-num-train-image-tokens",
@@ -508,7 +508,7 @@ def parse_args(args):
         type=int,
         nargs="+",
         default=None,
-        help="Patch sizes to sample for NaFlex training. Defaults to 16 when omitted."
+        help="Patch sizes to sample for NaFlex training. Eval uses the first value. Defaults to 16 when omitted."
     )
     parser.add_argument(
         "--naflex-patch-size-probs",
@@ -522,7 +522,7 @@ def parse_args(args):
         type=int,
         nargs="+",
         default=None,
-        help="Sequence lengths to sample for NaFlex training."
+        help="Sequence lengths to sample for NaFlex training. Eval pads/crops to the largest value."
     )
     parser.add_argument(
         "--naflex-max-image-tokens-per-batch",

--- a/src/open_clip_train/params.py
+++ b/src/open_clip_train/params.py
@@ -129,7 +129,7 @@ def parse_args(args):
         "--workers", type=int, default=4, help="Number of dataloader workers per GPU."
     )
     parser.add_argument(
-        "--batch-size", type=int, default=64, help="Batch size per GPU."
+        "--batch-size", type=int, default=64, help="Batch size per GPU. Ignored for NaFlex WebDataset training."
     )
     parser.add_argument(
         "--epochs", type=int, default=32, help="Number of epochs to train for."
@@ -487,6 +487,54 @@ def parse_args(args):
         default=None,
         type=str,
         help='A string to specify a specific distributed loss implementation.'
+    )
+    parser.add_argument(
+        "--use-naflex",
+        default=False,
+        action="store_true",
+        help="Use NaFlex WebDataset batching for training."
+    )
+    parser.add_argument(
+        "--naflex-num-train-image-tokens",
+        type=int,
+        default=None,
+        help=(
+            "Number of image tokens per training epoch for NaFlex schedule creation. "
+            "Use this instead of --train-num-samples to target a token budget."
+        ),
+    )
+    parser.add_argument(
+        "--naflex-patch-sizes",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Patch sizes to sample for NaFlex training. Defaults to 16 when omitted."
+    )
+    parser.add_argument(
+        "--naflex-patch-size-probs",
+        type=float,
+        nargs="+",
+        default=None,
+        help="Sampling probabilities for --naflex-patch-sizes."
+    )
+    parser.add_argument(
+        "--naflex-seq-lens",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Sequence lengths to sample for NaFlex training."
+    )
+    parser.add_argument(
+        "--naflex-max-image-tokens-per-batch",
+        type=int,
+        default=4096 * 4,
+        help="Maximum image tokens per local NaFlex batch."
+    )
+    parser.add_argument(
+        "--naflex-batch-divisor",
+        type=int,
+        default=8,
+        help="Divisibility constraint for scheduled NaFlex batch sizes."
     )
 
     args = parser.parse_args(args)

--- a/src/open_clip_train/params.py
+++ b/src/open_clip_train/params.py
@@ -495,6 +495,15 @@ def parse_args(args):
         help="Use NaFlex WebDataset batching for training and NaFlex patchified validation / zero-shot loaders."
     )
     parser.add_argument(
+        "--force-naflex-vision",
+        default=False,
+        action="store_true",
+        help=(
+            "Convert compatible timm EVA/ViT vision towers to NaFlexViT without enabling the NaFlex data pipeline. "
+            "--use-naflex implies this."
+        ),
+    )
+    parser.add_argument(
         "--naflex-num-train-image-tokens",
         type=int,
         default=None,
@@ -538,6 +547,11 @@ def parse_args(args):
     )
 
     args = parser.parse_args(args)
+    if args.use_naflex:
+        args.force_naflex_vision = True
+        args.aug_cfg = dict(args.aug_cfg or {})
+        args.aug_cfg["use_timm"] = True
+        args.aug_cfg["naflex"] = True
 
     if 'timm' not in args.opt:
         # set default opt params based on model name (only if timm optimizer not used)

--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -66,6 +66,29 @@ def get_batch_size(batch):
     return len(image)
 
 
+def is_naflex_batch(batch):
+    image = batch["image"]
+    return isinstance(image, dict) and "patches" in image
+
+
+def get_naflex_loss_scale(batch, args):
+    loss_scale = getattr(args, "naflex_loss_scale", "none")
+    if loss_scale in (None, "none") or not is_naflex_batch(batch):
+        return 1.0
+
+    batch_size = get_batch_size(batch)
+    reference_batch_size = getattr(args, "batch_size", None)
+    if reference_batch_size is None or reference_batch_size <= 0:
+        raise ValueError("NaFlex loss scaling requires a positive --batch-size reference.")
+
+    scale = batch_size / reference_batch_size
+    if loss_scale == "linear":
+        return scale
+    if loss_scale == "sqrt":
+        return math.sqrt(scale)
+    raise ValueError(f"Unsupported NaFlex loss scale: {loss_scale}")
+
+
 def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_writer=None):
     device = torch.device(args.device)
     autocast = get_autocast(
@@ -107,6 +130,9 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
                 losses = task(batch)
                 total_loss = losses["loss"]
 
+            loss_scale = get_naflex_loss_scale(batch, args)
+            if loss_scale != 1.0:
+                total_loss = total_loss * loss_scale
             backward(total_loss, scaler)
         else:
             # First, cache the features without any gradient tracking.
@@ -174,6 +200,9 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
                         losses["loss"] = total_loss
                         losses["logit_scale"] = logit_scale
 
+                    loss_scale = get_naflex_loss_scale(batch_j, args)
+                    if loss_scale != 1.0:
+                        total_loss = total_loss * loss_scale
                     backward(total_loss, scaler)
 
                 if use_fsdp_no_sync:

--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -194,9 +194,10 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
                 )
             optimizer.step()
 
-        step_batch_size = get_batch_size(batch)
         if args.accum_freq > 1:
             step_batch_size = sum(get_batch_size(accum_batch) for accum_batch in accum_batches)
+        else:
+            step_batch_size = get_batch_size(batch)
 
         # reset gradient accum, if enabled
         if args.accum_freq > 1:

--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -21,6 +21,7 @@ except ImportError:
 from open_clip import get_input_dtype, CLIP, CustomTextCLIP
 from open_clip.task import get_model_from_task
 from open_clip_train.distributed import is_master
+from open_clip_train.naflex_data import create_naflex_dummy_image, resolve_naflex_eval_config
 from open_clip_train.zero_shot import zero_shot_eval
 from open_clip_train.precision import get_autocast
 
@@ -306,13 +307,26 @@ def evaluate(task, data, epoch, args, tb_writer=None, tokenizer=None):
 
         if use_fsdp_eval:
             # Pre-allocate dummy batch for non-master ranks
-            dummy_batch = task.create_dummy_batch(
-                image_size=model.visual.image_size,
-                context_length=model.context_length,
-                batch_size=1,
-                device=device,
-                dtype=input_dtype,
-            )
+            if getattr(args, 'use_naflex', False):
+                patch_size, max_seq_len = resolve_naflex_eval_config(args)
+                dummy_batch = {
+                    "image": create_naflex_dummy_image(
+                        1,
+                        max_seq_len=max_seq_len,
+                        patch_size=patch_size,
+                        device=device,
+                        dtype=input_dtype,
+                    ),
+                    "text": torch.zeros(1, model.context_length, device=device, dtype=torch.long),
+                }
+            else:
+                dummy_batch = task.create_dummy_batch(
+                    image_size=model.visual.image_size,
+                    context_length=model.context_length,
+                    batch_size=1,
+                    device=device,
+                    dtype=input_dtype,
+                )
             signal = torch.zeros(1, device=device, dtype=torch.long)
 
         # FIXME this does not scale past small eval datasets

--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -21,7 +21,6 @@ except ImportError:
 from open_clip import get_input_dtype, CLIP, CustomTextCLIP
 from open_clip.task import get_model_from_task
 from open_clip_train.distributed import is_master
-from open_clip_train.naflex_data import create_naflex_dummy_image, resolve_naflex_eval_config
 from open_clip_train.zero_shot import zero_shot_eval
 from open_clip_train.precision import get_autocast
 
@@ -307,26 +306,11 @@ def evaluate(task, data, epoch, args, tb_writer=None, tokenizer=None):
 
         if use_fsdp_eval:
             # Pre-allocate dummy batch for non-master ranks
-            if getattr(args, 'use_naflex', False):
-                patch_size, max_seq_len = resolve_naflex_eval_config(args)
-                dummy_batch = {
-                    "image": create_naflex_dummy_image(
-                        1,
-                        max_seq_len=max_seq_len,
-                        patch_size=patch_size,
-                        device=device,
-                        dtype=input_dtype,
-                    ),
-                    "text": torch.zeros(1, model.context_length, device=device, dtype=torch.long),
-                }
-            else:
-                dummy_batch = task.create_dummy_batch(
-                    image_size=model.visual.image_size,
-                    context_length=model.context_length,
-                    batch_size=1,
-                    device=device,
-                    dtype=input_dtype,
-                )
+            dummy_batch = task.create_dummy_batch(
+                batch_size=1,
+                device=device,
+                dtype=input_dtype,
+            )
             signal = torch.zeros(1, device=device, dtype=torch.long)
 
         # FIXME this does not scale past small eval datasets

--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -59,6 +59,13 @@ def backward(total_loss, scaler):
         total_loss.backward()
 
 
+def get_batch_size(batch):
+    image = batch["image"]
+    if isinstance(image, dict):
+        return image["patches"].shape[0]
+    return len(image)
+
+
 def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_writer=None):
     device = torch.device(args.device)
     autocast = get_autocast(
@@ -82,6 +89,7 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
     batch_time_m = AverageMeter()
     data_time_m = AverageMeter()
     end = time.time()
+    num_samples = 0
     for i, batch in enumerate(dataloader):
         i_accum = i // args.accum_freq
         step = num_batches_per_epoch * epoch + i_accum
@@ -186,6 +194,10 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
                 )
             optimizer.step()
 
+        step_batch_size = get_batch_size(batch)
+        if args.accum_freq > 1:
+            step_batch_size = sum(get_batch_size(accum_batch) for accum_batch in accum_batches)
+
         # reset gradient accum, if enabled
         if args.accum_freq > 1:
             accum_batches, accum_features = [], {}
@@ -196,9 +208,8 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
         batch_time_m.update(time.time() - end)
         end = time.time()
         batch_count = i_accum + 1
+        num_samples += step_batch_size * args.world_size
         if is_master(args) and (i_accum % args.log_every_n_steps == 0 or batch_count == num_batches_per_epoch):
-            batch_size = len(batch["image"])
-            num_samples = batch_count * batch_size * args.accum_freq * args.world_size
             samples_per_epoch = dataloader.num_samples
             percent_complete = 100.0 * batch_count / num_batches_per_epoch
 
@@ -206,7 +217,7 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
             for key, val in losses.items():
                 if key not in losses_m:
                     losses_m[key] = AverageMeter()
-                losses_m[key].update(val.item(), batch_size)
+                losses_m[key].update(val.item(), step_batch_size)
 
             logit_scale = losses.get("logit_scale", None)
             logit_scale_scalar = logit_scale.item() if logit_scale is not None else 0.0
@@ -216,8 +227,8 @@ def train_one_epoch(task, data, epoch, optimizer, scaler, scheduler, args, tb_wr
                     for loss_name, loss_m in losses_m.items()
                 ]
             )
-            samples_per_second = args.accum_freq * args.batch_size * args.world_size / batch_time_m.val
-            samples_per_second_per_gpu = args.accum_freq * args.batch_size / batch_time_m.val
+            samples_per_second = step_batch_size * args.world_size / batch_time_m.val
+            samples_per_second_per_gpu = step_batch_size / batch_time_m.val
             _logger.info(
                 f"Train Epoch: {epoch} [{num_samples:>{sample_digits}}/{samples_per_epoch} ({percent_complete:.0f}%)] "
                 f"Data (t): {data_time_m.avg:.3f} "
@@ -344,7 +355,7 @@ def evaluate(task, data, epoch, args, tb_writer=None, tokenizer=None):
                     logits_per_image = logit_scale * image_features @ text_features.t()
                     logits_per_text = logits_per_image.t()
 
-                    batch_size = len(batch["image"])
+                    batch_size = get_batch_size(batch)
                     labels = torch.arange(batch_size, device=device).long()
                     total_loss = (
                         F.cross_entropy(logits_per_image, labels) +

--- a/src/open_clip_train/zero_shot.py
+++ b/src/open_clip_train/zero_shot.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 from open_clip import get_input_dtype, get_tokenizer, build_zero_shot_classifier, \
     IMAGENET_CLASSNAMES, OPENAI_IMAGENET_TEMPLATES
 from open_clip.task import get_model_from_task
-from open_clip_train.naflex_data import create_naflex_dummy_image, resolve_naflex_eval_config
 from open_clip_train.precision import get_autocast
 
 
@@ -35,7 +34,13 @@ def _image_batch_size(images) -> int:
     return images.size(0)
 
 
-def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=False, image_size=None):
+def _get_dummy_batch_creator(model_or_task):
+    if hasattr(model_or_task, "create_dummy_batch"):
+        return model_or_task.create_dummy_batch
+    return None
+
+
+def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=False):
     device = torch.device(args.device)
     autocast = get_autocast(
         args.precision,
@@ -46,17 +51,14 @@ def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=
     is_rank0 = (args.rank == 0)
 
     if use_fsdp_eval and not is_rank0:
-        # Pre-allocate dummy image tensor for non-master ranks
-        if getattr(args, 'use_naflex', False):
-            patch_size, max_seq_len = resolve_naflex_eval_config(args)
-            dummy_images = create_naflex_dummy_image(
-                1,
-                max_seq_len=max_seq_len,
-                patch_size=patch_size,
-                device=device,
-                dtype=input_dtype,
-            )
+        dummy_batch_creator = _get_dummy_batch_creator(model)
+        if dummy_batch_creator is not None:
+            dummy_images = dummy_batch_creator(batch_size=1, device=device, dtype=input_dtype)["image"]
         else:
+            if getattr(args, 'use_naflex', False):
+                raise ValueError("NaFlex FSDP zero-shot eval requires an ImageTextTask dummy batch interface.")
+            raw_model = get_model_from_task(model)
+            image_size = raw_model.visual.image_size
             if not isinstance(image_size, tuple):
                 image_size = (image_size, image_size)
             dummy_images = torch.zeros(1, 3, *image_size, device=device, dtype=input_dtype)
@@ -127,8 +129,6 @@ def zero_shot_eval(model_or_task, data, epoch, args, tokenizer=None):
     use_fsdp_eval = getattr(args, 'fsdp', False) and getattr(args, 'distributed', False)
     is_rank0 = (args.rank == 0)
 
-    model = get_model_from_task(model_or_task)
-
     if is_rank0:
         _logger.info('Starting zero-shot imagenet.')
 
@@ -161,15 +161,11 @@ def zero_shot_eval(model_or_task, data, epoch, args, tokenizer=None):
     if is_rank0:
         _logger.info('Using classifier')
 
-    # Extract image_size from raw model for FSDP dummy tensor allocation
-    image_size = model.visual.image_size if use_fsdp_eval else None
-
     results = {}
     if 'imagenet-val' in data:
         top1, top5 = run_zero_shot_classifier(
             model_or_task, classifier, data['imagenet-val'].dataloader, args,
             use_fsdp_eval=use_fsdp_eval,
-            image_size=image_size,
         )
         if is_rank0:
             results['imagenet-zeroshot-val-top1'] = top1
@@ -179,7 +175,6 @@ def zero_shot_eval(model_or_task, data, epoch, args, tokenizer=None):
         top1, top5 = run_zero_shot_classifier(
             model_or_task, classifier, data['imagenet-v2'].dataloader, args,
             use_fsdp_eval=use_fsdp_eval,
-            image_size=image_size,
         )
         if is_rank0:
             results['imagenetv2-zeroshot-val-top1'] = top1

--- a/src/open_clip_train/zero_shot.py
+++ b/src/open_clip_train/zero_shot.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 from open_clip import get_input_dtype, get_tokenizer, build_zero_shot_classifier, \
     IMAGENET_CLASSNAMES, OPENAI_IMAGENET_TEMPLATES
 from open_clip.task import get_model_from_task
+from open_clip_train.naflex_data import create_naflex_dummy_image, resolve_naflex_eval_config
 from open_clip_train.precision import get_autocast
 
 
@@ -16,6 +17,22 @@ def accuracy(output, target, topk=(1,)):
     pred = output.topk(max(topk), 1, True, True)[1].t()
     correct = pred.eq(target.view(1, -1).expand_as(pred))
     return [float(correct[:k].reshape(-1).float().sum(0, keepdim=True).cpu().numpy()) for k in topk]
+
+
+def _move_to_device(value, device, input_dtype=None):
+    if isinstance(value, torch.Tensor):
+        if value.is_floating_point():
+            return value.to(device=device, dtype=input_dtype, non_blocking=True)
+        return value.to(device=device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _move_to_device(val, device, input_dtype) for key, val in value.items()}
+    return value
+
+
+def _image_batch_size(images) -> int:
+    if isinstance(images, dict):
+        return images["patches"].shape[0]
+    return images.size(0)
 
 
 def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=False, image_size=None):
@@ -30,9 +47,19 @@ def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=
 
     if use_fsdp_eval and not is_rank0:
         # Pre-allocate dummy image tensor for non-master ranks
-        if not isinstance(image_size, tuple):
-            image_size = (image_size, image_size)
-        dummy_images = torch.zeros(1, 3, *image_size, device=device, dtype=input_dtype)
+        if getattr(args, 'use_naflex', False):
+            patch_size, max_seq_len = resolve_naflex_eval_config(args)
+            dummy_images = create_naflex_dummy_image(
+                1,
+                max_seq_len=max_seq_len,
+                patch_size=patch_size,
+                device=device,
+                dtype=input_dtype,
+            )
+        else:
+            if not isinstance(image_size, tuple):
+                image_size = (image_size, image_size)
+            dummy_images = torch.zeros(1, 3, *image_size, device=device, dtype=input_dtype)
 
     with torch.inference_mode():
         top1, top5, n = 0., 0., 0.
@@ -52,8 +79,8 @@ def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=
 
                 if is_rank0:
                     images, target = batch
-                    images = images.to(device=device, dtype=input_dtype)
-                    target = target.to(device)
+                    images = _move_to_device(images, device=device, input_dtype=input_dtype)
+                    target = target.to(device, non_blocking=True)
                 else:
                     images = dummy_images
 
@@ -66,11 +93,11 @@ def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=
                     acc1, acc5 = accuracy(logits, target, topk=(1, 5))
                     top1 += acc1
                     top5 += acc5
-                    n += images.size(0)
+                    n += _image_batch_size(images)
         else:
             for images, target in tqdm(dataloader, unit_scale=args.batch_size):
-                images = images.to(device=device, dtype=input_dtype)
-                target = target.to(device)
+                images = _move_to_device(images, device=device, input_dtype=input_dtype)
+                target = target.to(device, non_blocking=True)
 
                 with autocast():
                     # predict
@@ -82,7 +109,7 @@ def run_zero_shot_classifier(model, classifier, dataloader, args, use_fsdp_eval=
                 acc1, acc5 = accuracy(logits, target, topk=(1, 5))
                 top1 += acc1
                 top5 += acc5
-                n += images.size(0)
+                n += _image_batch_size(images)
 
     top1 = (top1 / n) if n else 0.
     top5 = (top5 / n) if n else 0.

--- a/tests/test_data_csv.py
+++ b/tests/test_data_csv.py
@@ -2,19 +2,23 @@
 import types
 
 import pandas as pd
+import pytest
 import torch
 from PIL import Image
 from torchvision import transforms
 
+import open_clip
+from open_clip.naflex_config import NaFlexDataConfig
 from open_clip_train.data import CsvDataset, get_csv_dataset
+from open_clip_train.naflex_data import NAFLEX_AVAILABLE
 
 
-def _make_csv(tmp_path, n=3):
+def _make_csv(tmp_path, n=3, image_size=(4, 4)):
     """Create a tiny TSV dataset with n image/caption pairs."""
     rows = []
     for i in range(n):
         p = tmp_path / f"{i}.png"
-        Image.new("RGB", (4, 4), color=(i, i, i)).save(p)
+        Image.new("RGB", image_size, color=(i, i, i)).save(p)
         rows.append({"filepath": str(p), "caption": f"cap_{i}"})
     csv_path = tmp_path / "data.tsv"
     pd.DataFrame(rows).to_csv(csv_path, sep="\t", index=False)
@@ -133,3 +137,84 @@ def test_get_csv_dataset_batches_are_dicts(tmp_path):
     assert isinstance(batch, dict)
     assert "image" in batch and "text" in batch
     assert batch["image"].shape[0] == 2
+
+
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_get_csv_dataset_naflex_train_outputs_patched_dict_batches(tmp_path):
+    csv_path = _make_csv(tmp_path, n=4, image_size=(32, 32))
+    args = types.SimpleNamespace(
+        train_data=str(csv_path),
+        val_data=str(csv_path),
+        csv_img_key="filepath",
+        csv_caption_key="caption",
+        csv_separator="\t",
+        distributed=False,
+        rank=0,
+        world_size=1,
+        seed=0,
+        batch_size=2,
+        workers=0,
+    )
+    transform_factory = lambda max_seq_len, patch_size: transforms.ToTensor()
+    transform_factory.is_naflex_transform_factory = True
+    tokenizer = lambda xs: [torch.tensor([len(x)]) for x in xs]
+    config = NaFlexDataConfig.resolve(
+        patch_sizes=[16],
+        seq_lens=[4],
+        max_tokens_per_batch=8,
+        batch_divisor=1,
+    )
+
+    info = get_csv_dataset(
+        args,
+        transform_factory,
+        is_train=True,
+        tokenizer=tokenizer,
+        naflex_data_config=config,
+    )
+    batch = next(iter(info.dataloader))
+
+    assert info.dataloader.num_batches == 2
+    assert set(batch.keys()) == {"image", "text"}
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["image"]["patch_coord"].shape == (2, 4, 2)
+    assert batch["image"]["patch_valid"].all()
+    assert batch["text"].shape == (2, 1)
+
+
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_get_csv_dataset_naflex_val_outputs_patched_dict_batches(tmp_path):
+    csv_path = _make_csv(tmp_path, n=2, image_size=(32, 32))
+    args = types.SimpleNamespace(
+        train_data=str(csv_path),
+        val_data=str(csv_path),
+        csv_img_key="filepath",
+        csv_caption_key="caption",
+        csv_separator="\t",
+        distributed=False,
+        batch_size=2,
+        workers=0,
+    )
+    _, _, preprocess_val = open_clip.create_model_and_transforms(
+        "naflex_ViT-B-16",
+        pretrained=None,
+        device="cpu",
+        aug_cfg={"use_timm": True, "naflex": True},
+    )
+    tokenizer = lambda xs: [torch.tensor([len(x)]) for x in xs]
+    config = NaFlexDataConfig.resolve(patch_sizes=[16], seq_lens=[4])
+
+    info = get_csv_dataset(
+        args,
+        preprocess_val,
+        is_train=False,
+        tokenizer=tokenizer,
+        naflex_data_config=config,
+    )
+    batch = next(iter(info.dataloader))
+
+    assert set(batch.keys()) == {"image", "text"}
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["image"]["patch_coord"].shape == (2, 4, 2)
+    assert batch["image"]["patch_valid"].all()
+    assert batch["text"].shape == (2, 1)

--- a/tests/test_factory_task.py
+++ b/tests/test_factory_task.py
@@ -15,6 +15,7 @@ os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
 import open_clip
 from open_clip import create_task
+from open_clip.naflex_config import NaFlexDataConfig
 from open_clip.task import CLIPTask, SigLIPTask, CoCaTask, DistillCLIPTask
 from open_clip.loss import ClipLoss, SigLipLoss, CoCaLoss, DistillClipLoss
 
@@ -139,3 +140,14 @@ def test_create_task_attaches_model_as_trainable_module():
     args = _make_args()
     task = create_task(args, model=model)
     assert task.trainable_module is model
+
+
+def test_create_task_configures_naflex_dummy_shape():
+    model = open_clip.create_model('RN50')
+    args = _make_args()
+    config = NaFlexDataConfig.resolve(patch_sizes=[16, 32], seq_lens=[4, 8])
+    task = create_task(args, model=model, naflex_data_config=config)
+    batch = task.create_dummy_batch(batch_size=2)
+
+    assert batch["image"]["patches"].shape == (2, 8, 16 * 16 * 3)
+    assert batch["text"].shape == (2, model.context_length)

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -14,7 +14,7 @@ from open_clip_train.naflex_data import (
     NAFLEX_AVAILABLE,
     NaFlexBatcher,
     collate_naflex_tuples,
-    resolve_naflex_eval_config,
+    create_naflex_data_config_from_args,
 )
 from open_clip_train.params import parse_args
 
@@ -173,11 +173,11 @@ def test_parse_naflex_args():
 def test_naflex_eval_config_rejects_non_positive_values():
     args = types.SimpleNamespace(naflex_patch_sizes=[16], naflex_seq_lens=[0, 4])
     with pytest.raises(ValueError, match="sequence lengths"):
-        resolve_naflex_eval_config(args)
+        create_naflex_data_config_from_args(args)
 
     args = types.SimpleNamespace(naflex_patch_sizes=[0], naflex_seq_lens=[4])
     with pytest.raises(ValueError, match="patch size"):
-        resolve_naflex_eval_config(args)
+        create_naflex_data_config_from_args(args)
 
 
 def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
@@ -207,7 +207,13 @@ def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
     )
     tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
 
-    info = get_wds_dataset(args, _transform_factory, is_train=True, tokenizer=tokenizer)
+    info = get_wds_dataset(
+        args,
+        _transform_factory,
+        is_train=True,
+        tokenizer=tokenizer,
+        naflex_data_config=create_naflex_data_config_from_args(args),
+    )
     batch = next(iter(info.dataloader))
 
     assert set(batch.keys()) == {"image", "text"}
@@ -242,7 +248,13 @@ def test_get_wds_dataset_naflex_rolls_over_non_resampled_input(tmp_path):
     )
     tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
 
-    info = get_wds_dataset(args, _transform_factory, is_train=True, tokenizer=tokenizer)
+    info = get_wds_dataset(
+        args,
+        _transform_factory,
+        is_train=True,
+        tokenizer=tokenizer,
+        naflex_data_config=create_naflex_data_config_from_args(args),
+    )
     batches = list(info.dataloader)
 
     assert len(batches) == 3
@@ -298,7 +310,13 @@ def test_get_wds_dataset_naflex_eval_outputs_patched_image_dict(tmp_path):
     )
     tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
 
-    info = get_wds_dataset(args, preprocess_val, is_train=False, tokenizer=tokenizer)
+    info = get_wds_dataset(
+        args,
+        preprocess_val,
+        is_train=False,
+        tokenizer=tokenizer,
+        naflex_data_config=create_naflex_data_config_from_args(args),
+    )
     batch = next(iter(info.dataloader))
 
     assert set(batch.keys()) == {"image", "text"}
@@ -331,7 +349,12 @@ def test_get_imagenet_naflex_eval_outputs_patched_image_dict(tmp_path):
         workers=0,
     )
 
-    info = get_imagenet(args, (preprocess_train, preprocess_val), "val")
+    info = get_imagenet(
+        args,
+        (preprocess_train, preprocess_val),
+        "val",
+        naflex_data_config=create_naflex_data_config_from_args(args),
+    )
     images, targets = next(iter(info.dataloader))
 
     assert images["patches"].shape == (2, 4, 16 * 16 * 3)
@@ -344,7 +367,12 @@ def test_get_imagenet_naflex_train_raises_clear_error():
     args = types.SimpleNamespace(use_naflex=True)
 
     with pytest.raises(ValueError, match="--imagenet-train"):
-        get_imagenet(args, (_transform_factory, _transform_factory), "train")
+        get_imagenet(
+            args,
+            (_transform_factory, _transform_factory),
+            "train",
+            naflex_data_config=create_naflex_data_config_from_args(args),
+        )
 
 
 def test_naflex_model_forward_accepts_eval_transform_image_dict():

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -180,6 +180,22 @@ def test_naflex_eval_config_rejects_non_positive_values():
         create_naflex_data_config_from_args(args)
 
 
+def test_naflex_data_config_uses_model_eval_seq_len_default():
+    args = types.SimpleNamespace(naflex_patch_sizes=[16], naflex_seq_lens=None)
+    config = create_naflex_data_config_from_args(args, default_eval_seq_len=576)
+
+    assert config.train_seq_lens == (128, 256, 576, 784, 1024)
+    assert config.eval_seq_len == 576
+
+
+def test_naflex_seq_lens_override_model_eval_seq_len_default():
+    args = types.SimpleNamespace(naflex_patch_sizes=[16], naflex_seq_lens=[64])
+    config = create_naflex_data_config_from_args(args, default_eval_seq_len=576)
+
+    assert config.train_seq_lens == (64,)
+    assert config.eval_seq_len == 64
+
+
 def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
     tar_path = tmp_path / "samples.tar"
     _write_tar(tar_path)

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -1,0 +1,179 @@
+import io
+import tarfile
+import types
+
+import pytest
+import torch
+from PIL import Image
+from torchvision import transforms
+
+from open_clip.transform import image_transform
+from open_clip_train.data import get_wds_dataset
+from open_clip_train.naflex_data import NAFLEX_AVAILABLE, NaFlexBatcher
+from open_clip_train.params import parse_args
+
+
+pytestmark = pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+
+
+def _transform_factory(max_seq_len, patch_size):
+    return transforms.ToTensor()
+
+
+_transform_factory.is_naflex_transform_factory = True
+
+
+def _samples(num_samples=4):
+    return [
+        {
+            "image": Image.new("RGB", (32, 32), color=(idx, idx, idx)),
+            "text": torch.tensor([idx], dtype=torch.long),
+        }
+        for idx in range(num_samples)
+    ]
+
+
+def test_naflex_batcher_returns_dict_batches():
+    batcher = NaFlexBatcher(
+        train_num_samples=4,
+        patch_size=16,
+        seq_lens=(4,),
+        max_tokens_per_batch=8,
+        transform_factory=_transform_factory,
+        batch_divisor=1,
+        shuffle=False,
+    )
+
+    batches = list(batcher.run(_samples()))
+
+    assert len(batches) == 2
+    batch = batches[0]
+    assert set(batch.keys()) == {"image", "text"}
+    assert set(batch["image"].keys()) == {"patches", "patch_coord", "patch_valid", "seq_len"}
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["image"]["patch_coord"].shape == (2, 4, 2)
+    assert batch["image"]["patch_valid"].all()
+    assert batch["text"].shape == (2, 1)
+
+
+def test_naflex_batcher_token_schedule_handles_distributed_padding():
+    batcher = NaFlexBatcher(
+        train_num_tokens=17,
+        patch_size=16,
+        seq_lens=(4,),
+        max_tokens_per_batch=8,
+        transform_factory=_transform_factory,
+        batch_divisor=1,
+        distributed=True,
+        rank=0,
+        world_size=2,
+        shuffle=False,
+    )
+
+    assert batcher.num_batches == 2
+    assert batcher.num_samples == 6
+
+
+def test_image_transform_naflex_returns_timm_transform_factory():
+    factory = image_transform(
+        32,
+        is_train=True,
+        aug_cfg={"use_timm": True, "naflex": True, "scale": (1.0, 1.0), "ratio": (1.0, 1.0)},
+    )
+
+    transform = factory(max_seq_len=4, patch_size=16)
+    image = transform(Image.new("RGB", (32, 32)))
+
+    assert getattr(factory, "is_naflex_transform_factory")
+    assert isinstance(image, torch.Tensor)
+    assert image.shape[-2:] == (32, 32)
+
+
+def test_image_transform_timm_non_naflex_remains_image_callable():
+    transform = image_transform(
+        32,
+        is_train=True,
+        aug_cfg={"use_timm": True, "scale": (1.0, 1.0), "ratio": (1.0, 1.0)},
+    )
+
+    image = transform(Image.new("RGB", (32, 32)))
+
+    assert isinstance(image, torch.Tensor)
+    assert image.shape == (3, 32, 32)
+
+
+def test_parse_naflex_args():
+    args = parse_args([
+        "--use-naflex",
+        "--naflex-num-train-image-tokens",
+        "1024",
+        "--naflex-patch-sizes",
+        "16",
+        "32",
+        "--naflex-patch-size-probs",
+        "0.25",
+        "0.75",
+        "--naflex-seq-lens",
+        "128",
+        "256",
+        "--naflex-max-image-tokens-per-batch",
+        "4096",
+        "--naflex-batch-divisor",
+        "4",
+    ])
+
+    assert args.use_naflex
+    assert args.naflex_num_train_image_tokens == 1024
+    assert args.naflex_patch_sizes == [16, 32]
+    assert args.naflex_patch_size_probs == [0.25, 0.75]
+    assert args.naflex_seq_lens == [128, 256]
+    assert args.naflex_max_image_tokens_per_batch == 4096
+    assert args.naflex_batch_divisor == 4
+
+
+def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
+    tar_path = tmp_path / "samples.tar"
+    with tarfile.open(tar_path, "w") as tar:
+        for idx in range(4):
+            image = Image.new("RGB", (32, 32), color=(idx, idx, idx))
+            image_file = io.BytesIO()
+            image.save(image_file, format="PNG")
+            image_file.seek(0)
+            image_info = tarfile.TarInfo(f"{idx}.png")
+            image_info.size = len(image_file.getbuffer())
+            tar.addfile(image_info, image_file)
+
+            text_file = io.BytesIO(str(idx).encode("utf-8"))
+            text_info = tarfile.TarInfo(f"{idx}.txt")
+            text_info.size = len(text_file.getbuffer())
+            tar.addfile(text_info, text_file)
+
+    args = types.SimpleNamespace(
+        train_data=str(tar_path),
+        val_data=None,
+        dataset_resampled=False,
+        train_data_upsampling_factors=None,
+        train_num_samples=4,
+        val_num_samples=None,
+        use_naflex=True,
+        naflex_num_train_image_tokens=None,
+        naflex_patch_sizes=[16],
+        naflex_patch_size_probs=None,
+        naflex_seq_lens=[4],
+        naflex_max_image_tokens_per_batch=8,
+        naflex_batch_divisor=1,
+        seed=0,
+        workers=0,
+        batch_size=2,
+        distributed=False,
+        rank=0,
+        world_size=1,
+    )
+    tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
+
+    info = get_wds_dataset(args, _transform_factory, is_train=True, tokenizer=tokenizer)
+    batch = next(iter(info.dataloader))
+
+    assert set(batch.keys()) == {"image", "text"}
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["text"].shape == (2, 1)

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -7,6 +7,7 @@ import torch
 from PIL import Image
 from torchvision import transforms
 
+import open_clip
 from open_clip.transform import image_transform
 from open_clip_train.data import get_wds_dataset
 from open_clip_train.naflex_data import NAFLEX_AVAILABLE, NaFlexBatcher
@@ -31,6 +32,23 @@ def _samples(num_samples=4):
         }
         for idx in range(num_samples)
     ]
+
+
+def _write_tar(path, num_samples=4):
+    with tarfile.open(path, "w") as tar:
+        for idx in range(num_samples):
+            image = Image.new("RGB", (32, 32), color=(idx, idx, idx))
+            image_file = io.BytesIO()
+            image.save(image_file, format="PNG")
+            image_file.seek(0)
+            image_info = tarfile.TarInfo(f"{idx}.png")
+            image_info.size = len(image_file.getbuffer())
+            tar.addfile(image_info, image_file)
+
+            text_file = io.BytesIO(str(idx).encode("utf-8"))
+            text_info = tarfile.TarInfo(f"{idx}.txt")
+            text_info.size = len(text_file.getbuffer())
+            tar.addfile(text_info, text_file)
 
 
 def test_naflex_batcher_returns_dict_batches():
@@ -72,6 +90,22 @@ def test_naflex_batcher_token_schedule_handles_distributed_padding():
 
     assert batcher.num_batches == 2
     assert batcher.num_samples == 6
+
+
+def test_naflex_batcher_pads_schedule_to_worker_count():
+    batcher = NaFlexBatcher(
+        train_num_samples=1,
+        patch_size=16,
+        seq_lens=(4,),
+        max_tokens_per_batch=8,
+        transform_factory=_transform_factory,
+        batch_divisor=1,
+        shuffle=False,
+    )
+
+    assert batcher.num_batches == 1
+    assert batcher.num_batches_for_workers(4) == 4
+    assert batcher.num_samples_for_workers(4) == 4
 
 
 def test_image_transform_naflex_returns_timm_transform_factory():
@@ -133,20 +167,7 @@ def test_parse_naflex_args():
 
 def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
     tar_path = tmp_path / "samples.tar"
-    with tarfile.open(tar_path, "w") as tar:
-        for idx in range(4):
-            image = Image.new("RGB", (32, 32), color=(idx, idx, idx))
-            image_file = io.BytesIO()
-            image.save(image_file, format="PNG")
-            image_file.seek(0)
-            image_info = tarfile.TarInfo(f"{idx}.png")
-            image_info.size = len(image_file.getbuffer())
-            tar.addfile(image_info, image_file)
-
-            text_file = io.BytesIO(str(idx).encode("utf-8"))
-            text_info = tarfile.TarInfo(f"{idx}.txt")
-            text_info.size = len(text_file.getbuffer())
-            tar.addfile(text_info, text_file)
+    _write_tar(tar_path)
 
     args = types.SimpleNamespace(
         train_data=str(tar_path),
@@ -177,3 +198,76 @@ def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
     assert set(batch.keys()) == {"image", "text"}
     assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
     assert batch["text"].shape == (2, 1)
+
+
+def test_get_wds_dataset_naflex_rolls_over_non_resampled_input(tmp_path):
+    tar_path = tmp_path / "samples.tar"
+    _write_tar(tar_path, num_samples=2)
+
+    args = types.SimpleNamespace(
+        train_data=str(tar_path),
+        val_data=None,
+        dataset_resampled=False,
+        train_data_upsampling_factors=None,
+        train_num_samples=6,
+        val_num_samples=None,
+        use_naflex=True,
+        naflex_num_train_image_tokens=None,
+        naflex_patch_sizes=[16],
+        naflex_patch_size_probs=None,
+        naflex_seq_lens=[4],
+        naflex_max_image_tokens_per_batch=8,
+        naflex_batch_divisor=1,
+        seed=0,
+        workers=0,
+        batch_size=2,
+        distributed=False,
+        rank=0,
+        world_size=1,
+    )
+    tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
+
+    info = get_wds_dataset(args, _transform_factory, is_train=True, tokenizer=tokenizer)
+    batches = list(info.dataloader)
+
+    assert len(batches) == 3
+    assert sum(batch["image"]["patches"].shape[0] for batch in batches) == 6
+
+
+def test_naflex_model_forward_accepts_batcher_image_dict():
+    samples = [
+        {
+            "image": Image.new("RGB", (32, 32), color=(idx, idx, idx)),
+            "text": torch.zeros(77, dtype=torch.long),
+        }
+        for idx in range(2)
+    ]
+    batcher = NaFlexBatcher(
+        train_num_samples=2,
+        patch_size=16,
+        seq_lens=(4,),
+        max_tokens_per_batch=8,
+        transform_factory=_transform_factory,
+        batch_divisor=1,
+        shuffle=False,
+    )
+    batch = next(iter(batcher.run(samples)))
+    model = open_clip.create_model("naflex_ViT-B-16", pretrained=None, device="cpu")
+
+    with torch.inference_mode():
+        image_features, text_features, _ = model(batch["image"], batch["text"])
+
+    assert image_features.shape == (2, 512)
+    assert text_features.shape == (2, 512)
+
+
+def test_naflex_model_forward_accepts_dense_image_tensor():
+    model = open_clip.create_model("naflex_ViT-B-16", pretrained=None, device="cpu")
+    image = torch.randn(2, 3, 32, 32)
+    text = torch.zeros(2, 77, dtype=torch.long)
+
+    with torch.inference_mode():
+        image_features, text_features, _ = model(image, text)
+
+    assert image_features.shape == (2, 512)
+    assert text_features.shape == (2, 512)

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -9,8 +9,13 @@ from torchvision import transforms
 
 import open_clip
 from open_clip.transform import image_transform
-from open_clip_train.data import get_wds_dataset
-from open_clip_train.naflex_data import NAFLEX_AVAILABLE, NaFlexBatcher
+from open_clip_train.data import get_imagenet, get_wds_dataset
+from open_clip_train.naflex_data import (
+    NAFLEX_AVAILABLE,
+    NaFlexBatcher,
+    collate_naflex_tuples,
+    resolve_naflex_eval_config,
+)
 from open_clip_train.params import parse_args
 
 
@@ -165,6 +170,16 @@ def test_parse_naflex_args():
     assert args.naflex_batch_divisor == 4
 
 
+def test_naflex_eval_config_rejects_non_positive_values():
+    args = types.SimpleNamespace(naflex_patch_sizes=[16], naflex_seq_lens=[0, 4])
+    with pytest.raises(ValueError, match="sequence lengths"):
+        resolve_naflex_eval_config(args)
+
+    args = types.SimpleNamespace(naflex_patch_sizes=[0], naflex_seq_lens=[4])
+    with pytest.raises(ValueError, match="patch size"):
+        resolve_naflex_eval_config(args)
+
+
 def test_get_wds_dataset_naflex_keeps_dictionary_contract(tmp_path):
     tar_path = tmp_path / "samples.tar"
     _write_tar(tar_path)
@@ -232,6 +247,125 @@ def test_get_wds_dataset_naflex_rolls_over_non_resampled_input(tmp_path):
 
     assert len(batches) == 3
     assert sum(batch["image"]["patches"].shape[0] for batch in batches) == 6
+
+
+def test_create_model_and_transforms_returns_naflex_eval_factory():
+    _, _, preprocess_val = open_clip.create_model_and_transforms(
+        "naflex_ViT-B-16",
+        pretrained=None,
+        device="cpu",
+        aug_cfg={"use_timm": True, "naflex": True},
+    )
+
+    transform = preprocess_val(max_seq_len=4, patch_size=16)
+    image = transform(Image.new("RGB", (32, 32)))
+
+    assert getattr(preprocess_val, "is_naflex_eval_transform_factory")
+    assert set(image.keys()) == {"patches", "patch_coord", "patch_valid"}
+    assert image["patches"].shape == (4, 16 * 16 * 3)
+    assert image["patch_coord"].shape == (4, 2)
+    assert image["patch_valid"].all()
+
+
+def test_get_wds_dataset_naflex_eval_outputs_patched_image_dict(tmp_path):
+    tar_path = tmp_path / "samples.tar"
+    _write_tar(tar_path)
+    _, _, preprocess_val = open_clip.create_model_and_transforms(
+        "naflex_ViT-B-16",
+        pretrained=None,
+        device="cpu",
+        aug_cfg={"use_timm": True, "naflex": True},
+    )
+    args = types.SimpleNamespace(
+        train_data=None,
+        val_data=str(tar_path),
+        dataset_resampled=False,
+        train_data_upsampling_factors=None,
+        train_num_samples=None,
+        val_num_samples=4,
+        use_naflex=True,
+        naflex_patch_sizes=[16],
+        naflex_patch_size_probs=None,
+        naflex_seq_lens=[4],
+        naflex_max_image_tokens_per_batch=8,
+        naflex_batch_divisor=1,
+        seed=0,
+        workers=0,
+        batch_size=2,
+        distributed=False,
+        rank=0,
+        world_size=1,
+    )
+    tokenizer = lambda text: [torch.tensor([int(text.strip())], dtype=torch.long)]
+
+    info = get_wds_dataset(args, preprocess_val, is_train=False, tokenizer=tokenizer)
+    batch = next(iter(info.dataloader))
+
+    assert set(batch.keys()) == {"image", "text"}
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["image"]["patch_coord"].shape == (2, 4, 2)
+    assert batch["image"]["patch_valid"].all()
+    assert batch["text"].shape == (2, 1)
+
+
+def test_get_imagenet_naflex_eval_outputs_patched_image_dict(tmp_path):
+    class_dir = tmp_path / "imagenet" / "class0"
+    class_dir.mkdir(parents=True)
+    for idx in range(2):
+        Image.new("RGB", (32, 32), color=(idx, idx, idx)).save(class_dir / f"{idx}.png")
+
+    _, preprocess_train, preprocess_val = open_clip.create_model_and_transforms(
+        "naflex_ViT-B-16",
+        pretrained=None,
+        device="cpu",
+        aug_cfg={"use_timm": True, "naflex": True},
+    )
+    args = types.SimpleNamespace(
+        imagenet_train=None,
+        imagenet_val=str(tmp_path / "imagenet"),
+        imagenet_v2=None,
+        use_naflex=True,
+        naflex_patch_sizes=[16],
+        naflex_seq_lens=[4],
+        batch_size=2,
+        workers=0,
+    )
+
+    info = get_imagenet(args, (preprocess_train, preprocess_val), "val")
+    images, targets = next(iter(info.dataloader))
+
+    assert images["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert images["patch_coord"].shape == (2, 4, 2)
+    assert images["patch_valid"].all()
+    assert targets.tolist() == [0, 0]
+
+
+def test_get_imagenet_naflex_train_raises_clear_error():
+    args = types.SimpleNamespace(use_naflex=True)
+
+    with pytest.raises(ValueError, match="--imagenet-train"):
+        get_imagenet(args, (_transform_factory, _transform_factory), "train")
+
+
+def test_naflex_model_forward_accepts_eval_transform_image_dict():
+    model, _, preprocess_val = open_clip.create_model_and_transforms(
+        "naflex_ViT-B-16",
+        pretrained=None,
+        device="cpu",
+        aug_cfg={"use_timm": True, "naflex": True},
+    )
+    transform = preprocess_val(max_seq_len=4, patch_size=16)
+    images, _ = collate_naflex_tuples(
+        [(transform(Image.new("RGB", (32, 32))), torch.tensor(0)) for _ in range(2)],
+        max_seq_len=4,
+    )
+    text = torch.zeros(2, 77, dtype=torch.long)
+
+    with torch.inference_mode():
+        image_features, text_features, _ = model(images, text)
+
+    assert image_features.shape == (2, 512)
+    assert text_features.shape == (2, 512)
 
 
 def test_naflex_model_forward_accepts_batcher_image_dict():

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -17,6 +17,7 @@ from open_clip_train.naflex_data import (
     create_naflex_data_config_from_args,
 )
 from open_clip_train.params import parse_args
+from open_clip_train.train import get_naflex_loss_scale
 
 
 pytestmark = pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
@@ -159,6 +160,8 @@ def test_parse_naflex_args():
         "4096",
         "--naflex-batch-divisor",
         "4",
+        "--naflex-loss-scale",
+        "sqrt",
     ])
 
     assert args.use_naflex
@@ -168,6 +171,27 @@ def test_parse_naflex_args():
     assert args.naflex_seq_lens == [128, 256]
     assert args.naflex_max_image_tokens_per_batch == 4096
     assert args.naflex_batch_divisor == 4
+    assert args.naflex_loss_scale == "sqrt"
+
+
+def test_naflex_loss_scale_defaults_to_none():
+    args = parse_args([])
+
+    assert args.naflex_loss_scale == "none"
+
+
+def test_naflex_loss_scale_uses_actual_batch_size():
+    batch = {"image": {"patches": torch.zeros(8, 4, 3)}, "text": torch.zeros(8, 1)}
+
+    assert get_naflex_loss_scale(batch, types.SimpleNamespace(naflex_loss_scale="none", batch_size=4)) == 1.0
+    assert get_naflex_loss_scale(batch, types.SimpleNamespace(naflex_loss_scale="linear", batch_size=4)) == 2.0
+    assert get_naflex_loss_scale(batch, types.SimpleNamespace(naflex_loss_scale="sqrt", batch_size=2)) == 2.0
+
+
+def test_naflex_loss_scale_ignores_dense_batches():
+    batch = {"image": torch.zeros(8, 3, 32, 32), "text": torch.zeros(8, 1)}
+
+    assert get_naflex_loss_scale(batch, types.SimpleNamespace(naflex_loss_scale="linear", batch_size=4)) == 1.0
 
 
 def test_naflex_eval_config_rejects_non_positive_values():

--- a/tests/test_naflex_config.py
+++ b/tests/test_naflex_config.py
@@ -1,5 +1,6 @@
 import pytest
 
+import open_clip
 from open_clip.naflex_config import NaFlexDataConfig
 
 
@@ -21,6 +22,24 @@ def test_naflex_data_config_resolves_train_and_eval_values():
     assert config.batch_divisor == 2
     assert config.variable_patch_size
     assert config.eval_config == ((16, 16), 8)
+
+
+def test_naflex_data_config_accepts_explicit_eval_seq_len():
+    config = NaFlexDataConfig.resolve(
+        patch_sizes=[16],
+        seq_lens=[128, 1024],
+        eval_seq_len=576,
+    )
+
+    assert config.train_seq_lens == (128, 1024)
+    assert config.eval_config == ((16, 16), 576)
+
+
+def test_siglip2_naflex_configs_default_to_384_dense_and_576_tokens():
+    for model_name in ("ViT-B-16-SigLIP2-naflex", "ViT-SO400M-16-SigLIP2-naflex"):
+        vision_cfg = open_clip.get_model_config(model_name)["vision_cfg"]
+        assert vision_cfg["image_size"] == 384
+        assert vision_cfg["image_seq_len"] == 576
 
 
 def test_naflex_data_config_rejects_negative_patch_size_probs():

--- a/tests/test_naflex_config.py
+++ b/tests/test_naflex_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+from open_clip.naflex_config import NaFlexDataConfig
+
+
+def test_naflex_data_config_resolves_train_and_eval_values():
+    config = NaFlexDataConfig.resolve(
+        patch_sizes=[16, 32],
+        patch_size_probs=[1, 3],
+        seq_lens=[4, 8],
+        train_num_image_tokens=128,
+        max_tokens_per_batch=64,
+        batch_divisor=2,
+    )
+
+    assert config.train_patch_sizes == ((16, 16), (32, 32))
+    assert config.train_patch_size_probs == (0.25, 0.75)
+    assert config.train_seq_lens == (4, 8)
+    assert config.train_num_image_tokens == 128
+    assert config.max_tokens_per_batch == 64
+    assert config.batch_divisor == 2
+    assert config.variable_patch_size
+    assert config.eval_config == ((16, 16), 8)
+
+
+def test_naflex_data_config_rejects_negative_patch_size_probs():
+    with pytest.raises(ValueError, match="non-negative"):
+        NaFlexDataConfig.resolve(
+            patch_sizes=[16, 32],
+            patch_size_probs=[-1, 2],
+            seq_lens=[4],
+        )

--- a/tests/test_naflex_timm_conversion.py
+++ b/tests/test_naflex_timm_conversion.py
@@ -1,5 +1,6 @@
 import types
 
+import numpy as np
 import pytest
 import torch
 import torch.nn as nn
@@ -67,6 +68,100 @@ def _tiny_native_vit_quickgelu_clip_config():
     config = _tiny_native_vit_clip_config()
     config["quick_gelu"] = True
     return config
+
+
+def _tiny_naflex_siglip2_clip_config():
+    config = _tiny_timm_clip_config("naflexvit_base_patch16_siglip")
+    config.update({
+        "custom_text": True,
+        "init_logit_bias": -10,
+    })
+    config["vision_cfg"].update({
+        "image_size": 32,
+        "timm_pool": "map",
+        "timm_model_kwargs": {
+            "patch_size": 16,
+            "embed_dim": 4,
+            "depth": 1,
+            "num_heads": 1,
+            "mlp_ratio": 2.0,
+            "pos_embed_grid_size": (2, 2),
+        },
+    })
+    config["text_cfg"].update({
+        "no_causal_mask": True,
+        "proj_bias": True,
+        "pool_type": "last",
+        "mlp_ratio": 2.0,
+    })
+    return config
+
+
+def _write_tiny_big_vision_npz(path):
+    rng = np.random.default_rng(0)
+    width = 4
+    mlp_width = 8
+    vocab_size = 16
+    context_length = 4
+    patch_dim = 16 * 16 * 3
+
+    def rand(shape):
+        return (0.02 * rng.standard_normal(shape)).astype(np.float32)
+
+    def add_encoder_block(weights, prefix, layers=1):
+        weights[f"{prefix}LayerNorm_0/scale"] = np.ones((layers, width), dtype=np.float32)
+        weights[f"{prefix}LayerNorm_0/bias"] = np.zeros((layers, width), dtype=np.float32)
+        weights[f"{prefix}LayerNorm_1/scale"] = np.ones((layers, width), dtype=np.float32)
+        weights[f"{prefix}LayerNorm_1/bias"] = np.zeros((layers, width), dtype=np.float32)
+        weights[f"{prefix}MultiHeadDotProductAttention_0/query/kernel"] = rand((layers, width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/key/kernel"] = rand((layers, width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/value/kernel"] = rand((layers, width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/query/bias"] = rand((layers, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/key/bias"] = rand((layers, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/value/bias"] = rand((layers, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/out/kernel"] = rand((layers, 1, width, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/out/bias"] = rand((layers, width))
+        weights[f"{prefix}MlpBlock_0/Dense_0/kernel"] = rand((layers, width, mlp_width))
+        weights[f"{prefix}MlpBlock_0/Dense_0/bias"] = rand((layers, mlp_width))
+        weights[f"{prefix}MlpBlock_0/Dense_1/kernel"] = rand((layers, mlp_width, width))
+        weights[f"{prefix}MlpBlock_0/Dense_1/bias"] = rand((layers, width))
+
+    def add_map_head(weights, prefix):
+        weights[f"{prefix}probe"] = rand((1, 1, width))
+        weights[f"{prefix}LayerNorm_0/scale"] = np.ones((width,), dtype=np.float32)
+        weights[f"{prefix}LayerNorm_0/bias"] = np.zeros((width,), dtype=np.float32)
+        weights[f"{prefix}MultiHeadDotProductAttention_0/query/kernel"] = rand((width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/key/kernel"] = rand((width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/value/kernel"] = rand((width, 1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/query/bias"] = rand((1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/key/bias"] = rand((1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/value/bias"] = rand((1, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/out/kernel"] = rand((1, width, width))
+        weights[f"{prefix}MultiHeadDotProductAttention_0/out/bias"] = rand((width,))
+        weights[f"{prefix}MlpBlock_0/Dense_0/kernel"] = rand((width, mlp_width))
+        weights[f"{prefix}MlpBlock_0/Dense_0/bias"] = rand((mlp_width,))
+        weights[f"{prefix}MlpBlock_0/Dense_1/kernel"] = rand((mlp_width, width))
+        weights[f"{prefix}MlpBlock_0/Dense_1/bias"] = rand((width,))
+
+    weights = {
+        "params/b": np.array([-1.0], dtype=np.float32),
+        "params/t": np.array([2.0], dtype=np.float32),
+        "params/img/embedding/kernel": rand((patch_dim, width)),
+        "params/img/embedding/bias": rand((width,)),
+        "params/img/pos_embedding": rand((2, 2, width)),
+        "params/img/Transformer/encoder_norm/scale": np.ones((width,), dtype=np.float32),
+        "params/img/Transformer/encoder_norm/bias": np.zeros((width,), dtype=np.float32),
+        "params/txt/Embed_0/embedding": rand((vocab_size, width)),
+        "params/txt/pos_embedding": rand((1, context_length, width)),
+        "params/txt/Encoder_0/encoder_norm/scale": np.ones((width,), dtype=np.float32),
+        "params/txt/Encoder_0/encoder_norm/bias": np.zeros((width,), dtype=np.float32),
+        "params/txt/head/kernel": rand((width, width)),
+        "params/txt/head/bias": rand((width,)),
+    }
+    add_encoder_block(weights, "params/img/Transformer/encoderblock/")
+    add_encoder_block(weights, "params/txt/Encoder_0/encoderblock/")
+    add_map_head(weights, "params/img/MAPHead_0/")
+    np.savez(path, **weights)
 
 
 def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
@@ -150,6 +245,53 @@ def test_naflex_data_config_defaults_to_model_patch_size():
 
     assert config.train_patch_sizes == ((14, 14),)
     assert config.eval_patch_size == (14, 14)
+
+
+def test_builtin_naflex_siglip2_configs_select_naflex_towers():
+    expected_towers = {
+        "ViT-B-16-SigLIP2-naflex": "naflexvit_base_patch16_siglip",
+        "ViT-SO400M-16-SigLIP2-naflex": "naflexvit_so400m_patch16_siglip",
+    }
+
+    for model_name, timm_model_name in expected_towers.items():
+        config = factory.get_model_config(model_name)
+
+        assert config["vision_cfg"]["timm_model_name"] == timm_model_name
+        assert config["vision_cfg"]["timm_pool"] == "map"
+        assert config["vision_cfg"]["timm_proj"] == "none"
+
+
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_big_vision_npz_loads_naflex_siglip2_tower(monkeypatch, tmp_path):
+    checkpoint_path = tmp_path / "tiny_siglip2_naflex.npz"
+    _write_tiny_big_vision_npz(checkpoint_path)
+    monkeypatch.setitem(factory._MODEL_CONFIGS, "test-naflex-siglip2", _tiny_naflex_siglip2_clip_config())
+
+    model = factory.create_model(
+        "test-naflex-siglip2",
+        pretrained=str(checkpoint_path),
+        output_dict=True,
+    )
+    model.eval()
+
+    trunk = model.visual.trunk
+    checkpoint = np.load(checkpoint_path)
+    expected_patch_weight = torch.from_numpy(checkpoint["params/img/embedding/kernel"].T)
+    assert trunk.__class__.__name__ == "NaFlexVit"
+    assert torch.equal(trunk.embeds.proj.weight, expected_patch_weight)
+    assert trunk.embeds.pos_embed.shape == (1, 2, 2, 4)
+    assert model.logit_scale.item() == pytest.approx(2.0)
+    assert model.logit_bias.item() == pytest.approx(-1.0)
+
+    image = torch.randn(1, 3, 32, 32)
+    text = torch.randint(0, model.vocab_size, (1, model.context_length))
+    with torch.inference_mode():
+        output = model(image=image, text=text)
+
+    assert output["image_features"].shape == (1, 4)
+    assert output["text_features"].shape == (1, 4)
+    assert torch.isfinite(output["image_features"]).all()
+    assert torch.isfinite(output["text_features"]).all()
 
 
 @pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")

--- a/tests/test_naflex_timm_conversion.py
+++ b/tests/test_naflex_timm_conversion.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 
 from open_clip import factory
+from open_clip import naflex_convert
 from open_clip_train.naflex_data import (
     NAFLEX_AVAILABLE,
     create_naflex_data_config_from_args,
@@ -41,6 +42,33 @@ def _tiny_timm_clip_config(timm_model_name):
     }
 
 
+def _tiny_native_vit_clip_config():
+    return {
+        "embed_dim": 4,
+        "vision_cfg": {
+            "image_size": 32,
+            "patch_size": 16,
+            "width": 4,
+            "layers": 1,
+            "head_width": 4,
+            "mlp_ratio": 2.0,
+        },
+        "text_cfg": {
+            "context_length": 4,
+            "vocab_size": 16,
+            "width": 4,
+            "heads": 1,
+            "layers": 1,
+        },
+    }
+
+
+def _tiny_native_vit_quickgelu_clip_config():
+    config = _tiny_native_vit_clip_config()
+    config["quick_gelu"] = True
+    return config
+
+
 def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
     captured = {}
 
@@ -60,8 +88,25 @@ def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
     assert captured["use_naflex"] is True
 
 
-def test_force_naflex_vision_rejects_non_timm_model():
-    with pytest.raises(RuntimeError, match="requires a timm vision tower"):
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_force_naflex_vision_converts_native_vit_config():
+    config = _tiny_native_vit_clip_config()
+    naflex_convert.apply_naflex_vision_config(config)
+
+    vision_cfg = config["vision_cfg"]
+    assert vision_cfg["timm_model_name"] == "vit_base_patch16_clip_224"
+    assert vision_cfg["timm_pool"] == "token"
+    assert vision_cfg["timm_proj"] == "linear"
+    assert vision_cfg["timm_model_kwargs"]["use_naflex"] is True
+    assert vision_cfg["timm_model_kwargs"]["patch_size"] == 16
+    assert vision_cfg["timm_model_kwargs"]["embed_dim"] == 4
+    assert vision_cfg["timm_model_kwargs"]["depth"] == 1
+    assert vision_cfg["timm_model_kwargs"]["num_heads"] == 1
+    assert vision_cfg["timm_model_kwargs"]["pos_embed_grid_size"] == (2, 2)
+
+
+def test_force_naflex_vision_rejects_non_vit_model():
+    with pytest.raises(RuntimeError, match="standard native OpenCLIP/OpenAI ViT"):
         factory.create_model(
             "RN50",
             load_weights=False,
@@ -129,8 +174,70 @@ def test_convert_naflex_timm_state_dict_maps_patch_embed_weight():
         "text.token_embedding.weight": torch.randn(16, 4),
     }
 
-    converted = factory._convert_naflex_timm_state_dict(model, state_dict)
+    converted = naflex_convert.convert_naflex_state_dict(model, state_dict)
 
     assert "visual.trunk.patch_embed.proj.weight" not in converted
     assert converted["visual.trunk.embeds.proj.weight"].shape == (4, 16 * 16 * 3)
     assert "text.token_embedding.weight" in converted
+
+
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_convert_naflex_native_vit_state_dict_folds_class_pos_embed():
+    state_dict = {
+        "visual.class_embedding": torch.ones(4),
+        "visual.positional_embedding": torch.arange(5 * 4, dtype=torch.float32).reshape(5, 4),
+        "visual.conv1.weight": torch.randn(4, 3, 16, 16),
+        "visual.ln_pre.weight": torch.ones(4),
+        "visual.ln_pre.bias": torch.zeros(4),
+        "visual.ln_post.weight": torch.ones(4),
+        "visual.ln_post.bias": torch.zeros(4),
+        "visual.proj": torch.randn(4, 4),
+        "visual.transformer.resblocks.0.ln_1.weight": torch.ones(4),
+        "visual.transformer.resblocks.0.ln_1.bias": torch.zeros(4),
+        "visual.transformer.resblocks.0.attn.in_proj_weight": torch.randn(12, 4),
+        "visual.transformer.resblocks.0.attn.in_proj_bias": torch.randn(12),
+        "visual.transformer.resblocks.0.attn.out_proj.weight": torch.randn(4, 4),
+        "visual.transformer.resblocks.0.attn.out_proj.bias": torch.randn(4),
+        "visual.transformer.resblocks.0.ln_2.weight": torch.ones(4),
+        "visual.transformer.resblocks.0.ln_2.bias": torch.zeros(4),
+        "visual.transformer.resblocks.0.mlp.c_fc.weight": torch.randn(8, 4),
+        "visual.transformer.resblocks.0.mlp.c_fc.bias": torch.randn(8),
+        "visual.transformer.resblocks.0.mlp.c_proj.weight": torch.randn(4, 8),
+        "visual.transformer.resblocks.0.mlp.c_proj.bias": torch.randn(4),
+        "text.token_embedding.weight": torch.randn(16, 4),
+    }
+
+    converted = naflex_convert._convert_naflex_native_vit_state_dict(state_dict)
+
+    expected_cls = state_dict["visual.class_embedding"] + state_dict["visual.positional_embedding"][0]
+    assert "visual.class_embedding" not in converted
+    assert "visual.positional_embedding" not in converted
+    assert torch.equal(converted["visual.trunk.embeds.cls_token"], expected_cls.reshape(1, 1, 4))
+    assert converted["visual.trunk.embeds.pos_embed"].shape == (1, 2, 2, 4)
+    assert converted["visual.trunk.embeds.proj.weight"].shape == (4, 16 * 16 * 3)
+    assert converted["visual.trunk.blocks.0.attn.qkv.weight"].shape == (12, 4)
+    assert converted["visual.trunk.blocks.0.mlp.fc1.weight"].shape == (8, 4)
+    assert "text.token_embedding.weight" in converted
+
+
+@pytest.mark.parametrize("config_fn", [_tiny_native_vit_clip_config, _tiny_native_vit_quickgelu_clip_config])
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_force_naflex_native_vit_dense_output_matches_native(monkeypatch, config_fn):
+    monkeypatch.setitem(factory._MODEL_CONFIGS, "test-native-vit-naflex", config_fn())
+
+    native = factory.create_model("test-native-vit-naflex", load_weights=False)
+    converted = factory.create_model(
+        "test-native-vit-naflex",
+        load_weights=False,
+        force_naflex_vision=True,
+    )
+    converted.load_state_dict(naflex_convert.convert_naflex_state_dict(converted, native.state_dict()), strict=True)
+    native.eval()
+    converted.eval()
+
+    image = torch.randn(2, 3, 32, 32)
+    with torch.inference_mode():
+        native_features = native.encode_image(image)
+        converted_features = converted.encode_image(image)
+
+    torch.testing.assert_close(converted_features, native_features, rtol=1e-5, atol=1e-5)

--- a/tests/test_naflex_timm_conversion.py
+++ b/tests/test_naflex_timm_conversion.py
@@ -1,0 +1,136 @@
+import types
+
+import pytest
+import torch
+import torch.nn as nn
+
+from open_clip import factory
+from open_clip_train.naflex_data import (
+    NAFLEX_AVAILABLE,
+    create_naflex_data_config_from_args,
+    get_naflex_model_patch_size,
+)
+from open_clip_train.params import parse_args
+
+
+class _DummyTimmTrunk(nn.Module):
+    num_features = 4
+    default_cfg = {}
+
+    def forward(self, x):
+        return torch.zeros(x.shape[0], self.num_features, device=x.device, dtype=x.dtype)
+
+
+def _tiny_timm_clip_config(timm_model_name):
+    return {
+        "embed_dim": 4,
+        "vision_cfg": {
+            "image_size": 224,
+            "timm_model_name": timm_model_name,
+            "timm_model_pretrained": False,
+            "timm_pool": "avg",
+            "timm_proj": "none",
+        },
+        "text_cfg": {
+            "context_length": 4,
+            "vocab_size": 16,
+            "width": 4,
+            "heads": 1,
+            "layers": 1,
+        },
+    }
+
+
+def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
+    captured = {}
+
+    def _create_model(_model_name, **kwargs):
+        captured.update(kwargs)
+        return _DummyTimmTrunk()
+
+    monkeypatch.setitem(factory._MODEL_CONFIGS, "test-eva-naflex", _tiny_timm_clip_config("eva02_test"))
+    monkeypatch.setattr("open_clip.timm_model.timm.create_model", _create_model)
+
+    factory.create_model(
+        "test-eva-naflex",
+        load_weights=False,
+        force_naflex_vision=True,
+    )
+
+    assert captured["use_naflex"] is True
+
+
+def test_force_naflex_vision_rejects_non_timm_model():
+    with pytest.raises(RuntimeError, match="requires a timm vision tower"):
+        factory.create_model(
+            "RN50",
+            load_weights=False,
+            force_naflex_vision=True,
+        )
+
+
+def test_parse_use_naflex_enables_timm_naflex_aug_cfg():
+    args = parse_args(["--use-naflex"])
+
+    assert args.force_naflex_vision is True
+    assert args.aug_cfg["use_timm"] is True
+    assert args.aug_cfg["naflex"] is True
+
+
+def test_parse_force_naflex_vision_does_not_enable_naflex_data_pipeline():
+    args = parse_args(["--force-naflex-vision"])
+
+    assert args.force_naflex_vision is True
+    assert args.use_naflex is False
+    assert "naflex" not in args.aug_cfg
+    assert "use_timm" not in args.aug_cfg
+
+
+def test_naflex_data_config_defaults_to_model_patch_size():
+    model = types.SimpleNamespace(
+        visual=types.SimpleNamespace(
+            trunk=types.SimpleNamespace(get_patch_size=lambda: (14, 14)),
+        ),
+    )
+    args = types.SimpleNamespace(
+        naflex_patch_sizes=None,
+        naflex_patch_size_probs=None,
+        naflex_seq_lens=[4],
+    )
+
+    config = create_naflex_data_config_from_args(
+        args,
+        default_patch_size=get_naflex_model_patch_size(model),
+    )
+
+    assert config.train_patch_sizes == ((14, 14),)
+    assert config.eval_patch_size == (14, 14)
+
+
+@pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")
+def test_convert_naflex_timm_state_dict_maps_patch_embed_weight():
+    from timm.models.naflexvit import NaFlexVit, NaFlexVitCfg
+
+    trunk = NaFlexVit(
+        cfg=NaFlexVitCfg(
+            patch_size=16,
+            embed_dim=4,
+            depth=1,
+            num_heads=1,
+            class_token=True,
+            global_pool="token",
+        ),
+        img_size=32,
+        num_classes=4,
+    )
+    model = types.SimpleNamespace(visual=types.SimpleNamespace(trunk=trunk))
+    state_dict = {
+        "visual.trunk.patch_embed.proj.weight": torch.randn(4, 3, 16, 16),
+        "text.token_embedding.weight": torch.randn(16, 4),
+    }
+
+    converted = factory._convert_naflex_timm_state_dict(model, state_dict)
+
+    assert "visual.trunk.patch_embed.proj.weight" not in converted
+    assert converted["visual.trunk.embeds.proj.weight"].shape == (4, 16 * 16 * 3)
+    assert "text.token_embedding.weight" in converted

--- a/tests/test_naflex_timm_conversion.py
+++ b/tests/test_naflex_timm_conversion.py
@@ -171,7 +171,7 @@ def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
         captured.update(kwargs)
         return _DummyTimmTrunk()
 
-    monkeypatch.setitem(factory._MODEL_CONFIGS, "test-eva-naflex", _tiny_timm_clip_config("eva02_test"))
+    monkeypatch.setitem(factory._MODEL_CONFIGS, "test-eva-naflex", _tiny_timm_clip_config("eva02_base_patch16_clip_224"))
     monkeypatch.setattr("open_clip.timm_model.timm.create_model", _create_model)
 
     factory.create_model(
@@ -181,6 +181,25 @@ def test_force_naflex_vision_passes_use_naflex_to_timm(monkeypatch):
     )
 
     assert captured["use_naflex"] is True
+
+
+def test_force_naflex_vision_accepts_timm_models_by_module_membership():
+    assert naflex_convert._can_convert_timm_model_to_naflex("eva02_base_patch16_clip_224")
+    assert naflex_convert._can_convert_timm_model_to_naflex("vit_base_patch16_224")
+    assert naflex_convert._can_convert_timm_model_to_naflex("vit_pe_core_base_patch16_224")
+    assert not naflex_convert._can_convert_timm_model_to_naflex("vit_not_registered_patch16_224")
+
+
+def test_force_naflex_vision_configures_pe_core_timm_tower():
+    config = factory.get_model_config("PE-Core-B-16")
+    naflex_convert.apply_naflex_vision_config(config)
+
+    vision_cfg = config["vision_cfg"]
+    assert vision_cfg["timm_model_name"] == "vit_pe_core_base_patch16_224"
+    assert vision_cfg["timm_pool"] == "map"
+    assert vision_cfg["timm_proj"] is None
+    assert vision_cfg["timm_model_kwargs"]["use_naflex"] is True
+    assert vision_cfg["timm_model_kwargs"]["pool_include_prefix"] is True
 
 
 @pytest.mark.skipif(not NAFLEX_AVAILABLE, reason="timm NaFlex data support is not available")

--- a/tests/test_task_base_unit.py
+++ b/tests/test_task_base_unit.py
@@ -11,6 +11,7 @@ import types
 import torch
 import torch.nn as nn
 
+from open_clip.naflex_config import NaFlexDataConfig
 from open_clip.task import CLIPTask
 
 
@@ -130,6 +131,20 @@ def test_create_dummy_batch_respects_dtype():
     batch = task.create_dummy_batch(image_size=8, context_length=5, dtype=torch.float16)
     assert batch["image"].dtype == torch.float16
     assert batch["text"].dtype == torch.long  # always long regardless of dtype
+
+
+def test_create_dummy_batch_uses_configured_naflex_shape():
+    task = CLIPTask(TinyModel(), loss=DummyLoss())
+    task.set_naflex_data_config(NaFlexDataConfig.resolve(patch_sizes=[16], seq_lens=[4]))
+
+    batch = task.create_dummy_batch(batch_size=2, dtype=torch.float16)
+
+    assert batch["image"]["patches"].shape == (2, 4, 16 * 16 * 3)
+    assert batch["image"]["patches"].dtype == torch.float16
+    assert batch["image"]["patch_coord"].shape == (2, 4, 2)
+    assert batch["image"]["patch_valid"].shape == (2, 4)
+    assert batch["image"]["seq_len"] == 4
+    assert batch["text"].shape == (2, 5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zero_shot_eval.py
+++ b/tests/test_zero_shot_eval.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import torch
 
 from open_clip_train import zero_shot as zero_shot_module
-from open_clip_train.naflex_data import create_naflex_dummy_image
 
 
 class _BareModel:
@@ -125,7 +124,12 @@ def test_run_zero_shot_classifier_accepts_naflex_image_dict():
 
     classifier = torch.zeros(2, 5)
     classifier[0, 0] = 1
-    images = create_naflex_dummy_image(2, max_seq_len=4, patch_size=16)
+    images = {
+        "patches": torch.zeros(2, 4, 16 * 16 * 3),
+        "patch_coord": torch.zeros(2, 4, 2, dtype=torch.long),
+        "patch_valid": torch.ones(2, 4, dtype=torch.bool),
+        "seq_len": 4,
+    }
     target = torch.zeros(2, dtype=torch.long)
     args = SimpleNamespace(
         device="cpu",
@@ -140,3 +144,44 @@ def test_run_zero_shot_classifier_accepts_naflex_image_dict():
 
     assert top1 == 1.0
     assert top5 == 1.0
+
+
+def test_run_zero_shot_classifier_uses_task_dummy_batch_for_fsdp_non_rank0(monkeypatch):
+    calls = []
+
+    class _Task:
+        def create_dummy_batch(self, batch_size, device, dtype):
+            calls.append((batch_size, device, dtype))
+            return {
+                "image": {
+                    "patches": torch.zeros(batch_size, 4, 16 * 16 * 3, device=device, dtype=dtype),
+                    "patch_coord": torch.zeros(batch_size, 4, 2, device=device, dtype=torch.long),
+                    "patch_valid": torch.ones(batch_size, 4, device=device, dtype=torch.bool),
+                    "seq_len": 4,
+                },
+                "text": torch.zeros(batch_size, 77, device=device, dtype=torch.long),
+            }
+
+        def __call__(self, image):
+            raise AssertionError("rank 1 should stop before forward when broadcast signal is zero")
+
+    monkeypatch.setattr(zero_shot_module.dist, "broadcast", lambda *_args, **_kwargs: None)
+    args = SimpleNamespace(
+        device="cpu",
+        precision="fp32",
+        batch_size=2,
+        rank=1,
+        fsdp=True,
+        use_naflex=True,
+    )
+
+    top1, top5 = zero_shot_module.run_zero_shot_classifier(
+        _Task(),
+        torch.zeros(2, 5),
+        [],
+        args,
+        use_fsdp_eval=True,
+    )
+
+    assert (top1, top5) == (0., 0.)
+    assert calls == [(1, torch.device("cpu"), None)]

--- a/tests/test_zero_shot_eval.py
+++ b/tests/test_zero_shot_eval.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
+import torch
+
 from open_clip_train import zero_shot as zero_shot_module
+from open_clip_train.naflex_data import create_naflex_dummy_image
 
 
 class _BareModel:
@@ -111,3 +114,29 @@ def test_zero_shot_eval_unwraps_wrapped_model_once(monkeypatch):
     # get_model_from_task unwraps .module from the DDP-like wrapper
     assert build_models == [wrapped_model]  # build_zero_shot_classifier gets model_or_task
     assert run_models == [wrapped_model]  # run_zero_shot_classifier gets model_or_task
+
+
+def test_run_zero_shot_classifier_accepts_naflex_image_dict():
+    class _Model:
+        def __call__(self, image):
+            features = torch.zeros(image["patches"].shape[0], 2)
+            features[:, 0] = 1
+            return {"image_features": features}
+
+    classifier = torch.zeros(2, 5)
+    classifier[0, 0] = 1
+    images = create_naflex_dummy_image(2, max_seq_len=4, patch_size=16)
+    target = torch.zeros(2, dtype=torch.long)
+    args = SimpleNamespace(
+        device="cpu",
+        precision="fp32",
+        batch_size=2,
+        rank=0,
+        fsdp=False,
+        use_naflex=True,
+    )
+
+    top1, top5 = zero_shot_module.run_zero_shot_classifier(_Model(), classifier, [(images, target)], args)
+
+    assert top1 == 1.0
+    assert top5 == 1.0


### PR DESCRIPTION
An alternative to #1147, post task-refactor

- Move NaFlex schedule, patchify, and collation logic into open_clip_train/naflex_data.py instead of embedding it in data.py.
- Keep the current dict batch contract, including nested image patch dicts.
- Reuse recursive task.prepare_batch() and only adjust variable batch-size accounting in train/eval logging.
- Rely on timm NaFlex model dict input support instead of special-casing TimmModel.forward().
- Return a timm transform factory only for aug_cfg naflex=True; keep normal use_timm=True transforms image-callable.
- Add NaFlex CLI options for token budgets, patch sizes/probs, sequence lengths, max tokens, and batch divisor.
- Cover NaFlex batching, token scheduling, transform behavior, args, and WDS dict output with tests.