### PR TITLE
Support extra timm transform parameters

### DIFF
--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -411,6 +411,8 @@ def image_transform(
             else:
                 input_size = (3, image_size, image_size)
 
+            aug_cfg_dict.setdefault('color_jitter', None)  # disable by default
+
             timm_transform_kwargs = dict(
                 input_size=input_size,
                 is_training=True,

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -61,6 +61,8 @@ def merge_preprocess_kwargs(base: PreprocessCfg, **kwargs):
 
 @dataclass
 class AugmentationCfg:
+    hflip: float = 0.0
+    vflip: float = 0.0
     scale: Tuple[float, float] = (0.9, 1.0)
     ratio: Optional[Tuple[float, float]] = None
     color_jitter: Optional[Union[float, Tuple[float, float, float], Tuple[float, float, float, float]]] = None
@@ -409,15 +411,9 @@ def image_transform(
             else:
                 input_size = (3, image_size, image_size)
 
-            aug_cfg_dict.setdefault('color_jitter', None)  # disable by default
-            # drop extra non-timm items
-            aug_cfg_dict.pop('color_jitter_prob', None)
-            aug_cfg_dict.pop('gray_scale_prob', None)
-
             timm_transform_kwargs = dict(
                 input_size=input_size,
                 is_training=True,
-                hflip=0.,
                 mean=mean,
                 std=std,
                 re_mode='pixel',

--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -1,7 +1,7 @@
 import numbers
 import random
 import warnings
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, InitVar
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -72,8 +72,18 @@ class AugmentationCfg:
     use_timm: bool = False
 
     # params for simclr_jitter_gray
-    color_jitter_prob: float = None
-    gray_scale_prob: float = None
+    color_jitter_prob: Optional[float] = None
+    grayscale_prob: Optional[float] = None
+
+    # For backwards compatibility
+    gray_scale_prob: InitVar[Optional[float]] = None
+
+    def __post_init__(self, gray_scale_prob):
+        if gray_scale_prob is not None and self.grayscale_prob is not None:
+            raise ValueError("Only one of `gray_scale_prob` or `grayscale_prob` should be specified, not both.")
+
+        if gray_scale_prob is not None:
+            self.grayscale_prob = gray_scale_prob
 
 
 class NaFlexTransformFactory:
@@ -442,9 +452,9 @@ def image_transform(
                 train_transform.extend([
                     color_jitter(*aug_cfg.color_jitter, p=aug_cfg.color_jitter_prob)
                 ])
-            if aug_cfg.gray_scale_prob:
+            if aug_cfg.grayscale_prob:
                 train_transform.extend([
-                    gray_scale(aug_cfg.gray_scale_prob)
+                    gray_scale(aug_cfg.grayscale_prob)
                 ])
             train_transform.extend([
                 MaybeToTensor(),


### PR DESCRIPTION
timm has had support for the `color_jitter_prob` and `gray_scale_prob` parameters since its version v0.9.16[^1], which were introduced by https://github.com/huggingface/pytorch-image-models/pull/2064

Given how its dependency version was bumped by #1097 (in this commit: https://github.com/mlfoundations/open_clip/pull/1097/changes/6641590880a7a540eec94ec4bb8203635df0dc99), it should be safe to use those parameters from the `AugmentationCfg` class without popping them out, while still keeping sane defaults in order to maintain backwards compatibility.

Also taking the chance to move `hflip` to the config as well, allowing one to adjust it now, and adding `vflip` while we are at it.

I wonder how much of timm's `create_transform` arguments should be surfaced here, and if a bigger refactor of this module should take place, given that the dependency on timm doesn't look to be optional anymore since https://github.com/mlfoundations/open_clip/pull/357, so all code paths that have it as optional could likely be dropped.

[^1]: https://github.com/huggingface/pytorch-image-models/releases/tag/v0.9.16