### PR TITLE
Fix NaFlex worker-padded sample count after schedule shuffle

### DIFF
--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -641,9 +641,9 @@ class NaFlexBatchScheduler:
 
     def epoch_schedule(self, epoch: int, num_workers: int = 1) -> List[Tuple[int, int]]:
         schedule = list(self._canonical_batch_schedule)
+        schedule = self.pad_schedule_for_workers(schedule, max(1, num_workers))
         if self.shuffle:
             random.Random(self.seed + epoch).shuffle(schedule)
-        schedule = self.pad_schedule_for_workers(schedule, max(1, num_workers))
         return schedule
 
     @staticmethod

--- a/src/open_clip_train/naflex_data.py
+++ b/src/open_clip_train/naflex_data.py
@@ -639,9 +639,14 @@ class NaFlexBatchScheduler:
     def __len__(self) -> int:
         return self.num_batches
 
+    def _worker_padded_schedule(self, num_workers: int) -> List[Tuple[int, int]]:
+        return self.pad_schedule_for_workers(
+            list(self._canonical_batch_schedule),
+            max(1, num_workers),
+        )
+
     def epoch_schedule(self, epoch: int, num_workers: int = 1) -> List[Tuple[int, int]]:
-        schedule = list(self._canonical_batch_schedule)
-        schedule = self.pad_schedule_for_workers(schedule, max(1, num_workers))
+        schedule = self._worker_padded_schedule(num_workers)
         if self.shuffle:
             random.Random(self.seed + epoch).shuffle(schedule)
         return schedule
@@ -668,11 +673,10 @@ class NaFlexBatchScheduler:
         return schedule[worker_id::num_workers]
 
     def num_batches_for_workers(self, num_workers: int) -> int:
-        schedule = self.pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
-        return len(schedule)
+        return len(self._worker_padded_schedule(num_workers))
 
     def num_samples_for_workers(self, num_workers: int) -> int:
-        schedule = self.pad_schedule_for_workers(list(self._canonical_batch_schedule), max(1, num_workers))
+        schedule = self._worker_padded_schedule(num_workers)
         num_samples_per_rank = sum(batch_size for _, batch_size in schedule)
         if self.distributed:
             return num_samples_per_rank * self.world_size

--- a/tests/test_naflex.py
+++ b/tests/test_naflex.py
@@ -224,6 +224,28 @@ def test_naflex_batcher_pads_schedule_to_worker_count():
     assert batcher.num_samples_for_workers(4) == 4
 
 
+def test_naflex_batcher_worker_padded_sample_count_matches_shuffled_epochs():
+    """Padding before shuffling keeps the advertised worker-padded sample count stable across epochs."""
+    batcher = NaFlexBatcher(
+        train_num_samples=17,
+        patch_size=16,
+        seq_lens=(4, 8, 16),
+        seq_len_choice_probs=(1, 2, 1),
+        max_tokens_per_batch=32,
+        transform_factory=_transform_factory,
+        batch_divisor=1,
+        seed=7,
+        shuffle=True,
+    )
+
+    expected_samples = batcher.num_samples_for_workers(4)
+    expected_batches = batcher.num_batches_for_workers(4)
+    for epoch in range(5):
+        schedule = batcher.scheduler.epoch_schedule(epoch, num_workers=4)
+        assert len(schedule) == expected_batches
+        assert sum(batch_size for _, batch_size in schedule) == expected_samples
+
+
 def test_image_transform_naflex_returns_timm_transform_factory():
     factory = image_transform(
         32,


### PR DESCRIPTION
When NaFlex schedules are shuffled before worker padding, the repeated padding batch can differ by epoch. 
num_samples_for_workers() computes metadata from the unshuffled padded schedule, so dataloader.num_samples can disagree with the actual number of rows yielded.

Example:
canonical: [(8, 4), (4, 8), (4, 5)] -> 17 samples
epoch 0 shuffled+worker-padded actual sum: 22
advertised num_samples_for_workers(4): 21

Fix: pad the schedule before epoch shuffle, so worker-padded batch count and sample count stay stable across epochs.
