### PR TITLE
Use compact key-only masks for GenLIP/GenLAP encoders

### DIFF
--- a/src/open_clip/naflex_genlip_model.py
+++ b/src/open_clip/naflex_genlip_model.py
@@ -540,13 +540,8 @@ def packed_caption_loss(model, prefix_emb, prefix_valid, block_pos, text, text_v
 
 
 def build_patch_attn_mask(patch_valid: torch.Tensor) -> torch.Tensor:
-    """Full bidirectional mask over valid patch tokens (encoder-only mode), ``(B, 1, Ni, Ni)``."""
-    pv = patch_valid.bool()
-    b, ni = pv.shape
-    allowed = (pv[:, :, None] & pv[:, None, :]).clone()
-    idx = torch.arange(ni, device=pv.device)
-    allowed[:, idx, idx] = True
-    return allowed.unsqueeze(1)
+    """Compact key-padding mask for bidirectional patch attention, ``(B, 1, 1, Ni)``."""
+    return patch_valid.bool()[:, None, None, :]
 
 
 def build_image_position_ids(patch_coord: torch.Tensor, patch_valid: torch.Tensor) -> torch.Tensor:

--- a/tests/test_naflex_genlip.py
+++ b/tests/test_naflex_genlip.py
@@ -108,10 +108,16 @@ def test_encode_image():
     feats = model.encode_image(batch['image'])
     assert feats.shape == (batch['image']['patches'].shape[0], model.embed_dim)
     assert torch.isfinite(feats).all()
-    # image-only full attention mask is symmetric over valid patches
+    # Encoder-only attention uses a broadcastable key-padding mask.
     pv = batch['image']['patch_valid']
-    m = build_patch_attn_mask(pv)[0, 0]
-    assert m[0, :].sum() == int(pv[0].sum())
+    m = build_patch_attn_mask(pv)
+    assert m.shape == (pv.shape[0], 1, 1, pv.shape[1])
+    assert torch.equal(m[:, 0, 0], pv)
+
+    corrupted = {k: v.clone() for k, v in batch['image'].items()}
+    corrupted['patches'][~pv] = 1e4
+    corrupted_feats = model.encode_image(corrupted)
+    torch.testing.assert_close(corrupted_feats, feats)
 
 
 def test_mrope_section_assertion():


### PR DESCRIPTION
## Summary

Replace the full `[B, 1, N, N]` boolean mask used by `GenLIP.encode_image()` and `GenLAP.encode_audio()` with a broadcastable `[B, 1, 1, N]` key-only mask. This reduces mask memory from `O(B * N^2)` to `O(B * N)`.

For valid queries, `query_valid & key_valid` is equivalent to `key_valid`. Invalid keys remain masked, while invalid query outputs are discarded by masked pooling, so encoded features are unchanged.

The query-dependent image/audio + text prefix-LM masks are not changed.

This is the same key-only mask optimization proposed for timm NaFlexVit in [huggingface/pytorch-image-models#2719](https://github.com/huggingface/pytorch-image-models/pull/2719), applied here to the custom GenLIP/GenLAP attention stack that does not use timm NaFlexVit.

## Tests

Updated `test_encode_image` to verify the compact mask shape and confirm that padded patch values do not affect encoded features.
