### PR TITLE
Set the default eval length for NaFlex ViT-B-16

### DIFF
--- a/src/open_clip/model_configs/naflex_ViT-B-16.json
+++ b/src/open_clip/model_configs/naflex_ViT-B-16.json
@@ -3,6 +3,7 @@
     "custom_text": true,
     "vision_cfg": {
         "image_size": 224,
+        "image_seq_len": 196,
         "timm_model_name": "naflexvit_base_patch16_gap",
         "timm_model_pretrained": false
     },

--- a/tests/test_naflex_config.py
+++ b/tests/test_naflex_config.py
@@ -46,11 +46,18 @@ def test_naflex_data_config_infers_budget_from_longest_row_cost():
     assert explicit.resolve_max_tokens_per_batch(batch_size=32, per_row_text_tokens=77) == 12345
 
 
-def test_siglip2_naflex_configs_default_to_384_dense_and_576_tokens():
-    for model_name in ("ViT-B-16-SigLIP2-naflex", "ViT-SO400M-16-SigLIP2-naflex"):
-        vision_cfg = open_clip.get_model_config(model_name)["vision_cfg"]
-        assert vision_cfg["image_size"] == 384
-        assert vision_cfg["image_seq_len"] == 576
+@pytest.mark.parametrize(
+    ("model_name", "image_size", "image_seq_len"),
+    [
+        ("naflex_ViT-B-16", 224, 196),
+        ("ViT-B-16-SigLIP2-naflex", 384, 576),
+        ("ViT-SO400M-16-SigLIP2-naflex", 384, 576),
+    ],
+)
+def test_naflex_configs_define_nominal_image_seq_len(model_name, image_size, image_seq_len):
+    vision_cfg = open_clip.get_model_config(model_name)["vision_cfg"]
+    assert vision_cfg["image_size"] == image_size
+    assert vision_cfg["image_seq_len"] == image_seq_len
 
 
 def test_naflex_data_config_rejects_negative_patch_size_probs():


### PR DESCRIPTION
## Problem

`naflex_ViT-B-16` did not specify `image_seq_len`, so evaluation fell back to the largest default training sequence length, 1024, instead of its nominal 224/P16 grid of 196 tokens.

## Change

Set `vision_cfg.image_seq_len` to 196, consistent with the existing image and patch sizes.

## Tests

Extended the existing NaFlex config coverage with the 224px image size and 196-token evaluation length.