### PR TITLE
Fix GenerationMixin compat with transformers>=5.14.0

### DIFF
--- a/src/open_clip/generation.py
+++ b/src/open_clip/generation.py
@@ -92,6 +92,15 @@ class MultimodalGenerationWrapper(nn.Module, GenerationMixin):
     def device(self) -> torch.device:
         return self._image_embs.device
 
+    def get_experts_implementation(self) -> dict:
+        # GenerationMixin.generate() (transformers>=5.14.0) unconditionally calls this from
+        # _optimize_model_for_decode() to snapshot/restore MoE routing config. It's normally
+        # only defined on transformers.PreTrainedModel, which this wrapper doesn't subclass.
+        # This wrapper never has MoE submodels, so there's nothing to report; an empty dict
+        # makes the caller's `"grouped_mm" in experts_implementation.values()` check a no-op.
+        # See https://github.com/mlfoundations/open_clip/issues/1199
+        return {}
+
     def prepare_inputs_for_generation(
             self,
             input_ids,


### PR DESCRIPTION
Fixes #1199

## Summary

`transformers` 5.14.0 added a call to `self.get_experts_implementation()` inside GenerationMixin._optimize_model_for_decode()`, invoked unconditionally from `generate()`'s decode loop. That method is only defined on `transformers.PreTrainedModel`, not on `GenerationMixin` itself. `MultimodalGenerationWrapper` (`src/open_clip/generation.py`) only inherits `nn.Module` + `GenerationMixin` by design -- it's a thin wrapper around
open_clip's own generative models, not a full `PreTrainedModel` -- so it breaks: `AttributeError: 'MultimodalGenerationWrapper' object has no attribute 'get_experts_implementation'`. Full analysis and bisection in #1199.

Fix: a trivial override. This wrapper never has MoE submodels, so there's nothing to report -- an empty dict makes the caller's `"grouped_mm" in experts_implementation.values()` check a no-op, restoring correct behavior.

## Test plan

- `tests/test_coca2.py` (27 tests, including `test_modern_coca_generate` and all `test_coca_generate_*`) -- pass against `transformers==5.14.1` (the actual broken version) with this fix, unpinned.
- `tests/test_naflex_mammut.py`, `tests/test_mammut.py` -- all `generate`-related tests across MaMMUT/NaFlex variants also pass.
- Confirmed the failure reproduces without this fix (same versions), and confirmed 85/85 tests pass across the three files with it.