### PR TITLE
Use one NaFlex linear loss scale per accumulation window

### DIFF
--- a/src/open_clip_train/train.py
+++ b/src/open_clip_train/train.py
@@ -216,6 +216,18 @@ def _train_step_eager(task, batch, accum_state, optimizer, scaler, autocast, arg
     # Now, ready to take gradients for the last accum_freq batches.
     # Re-do the forward pass for those batches, and use the cached features from the other batches as negatives.
     # Call backwards each time, but only step optimizer at the end.
+    window_linear_loss_scale = None
+    if (
+        getattr(args, 'naflex_loss_scale', 'none') == 'linear'
+        and all(is_naflex_batch(accum_batch) for accum_batch in accum_batches)
+    ):
+        reference_batch_size = getattr(args, 'batch_size', None)
+        if reference_batch_size is None or reference_batch_size <= 0:
+            raise ValueError("NaFlex loss scaling requires a positive --batch-size reference.")
+        # Each replay differentiates the same window-wide loss, so its coefficient must match.
+        window_batch_size = sum(task.batch_size(accum_batch) for accum_batch in accum_batches)
+        window_linear_loss_scale = window_batch_size / (len(accum_batches) * reference_batch_size)
+
     optimizer.zero_grad()
     for j in range(args.accum_freq):
         batch_j = accum_batches[j]
@@ -253,7 +265,11 @@ def _train_step_eager(task, batch, accum_state, optimizer, scaler, autocast, arg
                 total_loss = sum(v for k, v in losses.items() if k.endswith('_loss'))
                 losses["loss"] = total_loss
 
-            loss_scale = get_naflex_loss_scale(batch_j, args, task)
+            loss_scale = (
+                window_linear_loss_scale
+                if window_linear_loss_scale is not None
+                else get_naflex_loss_scale(batch_j, args, task)
+            )
             if loss_scale != 1.0:
                 total_loss = total_loss * loss_scale
             backward(total_loss, scaler)

--- a/tests/test_grad_accum.py
+++ b/tests/test_grad_accum.py
@@ -122,6 +122,61 @@ def test_grad_accum_no_accum_path_unchanged():
         assert torch.allclose(grads_step[name], grads_ref[name], rtol=1e-9, atol=1e-12), name
 
 
+@pytest.mark.parametrize('sizes', [(1, 2), (2, 1), (2, 2)])
+@pytest.mark.parametrize('loss_scale', ['linear', 'none'])
+def test_naflex_accum_matches_scaled_full_batch(sizes, loss_scale):
+    torch.manual_seed(0)
+    model = CLIP(
+        embed_dim=32,
+        vision_cfg=dict(
+            timm_model_name='naflexvit_base_patch16_gap',
+            timm_model_kwargs=dict(embed_dim=32, depth=2, num_heads=2),
+        ),
+        text_cfg=dict(context_length=8, vocab_size=64, width=32, heads=2, layers=2),
+        output_dict=True,
+    ).double()
+    task = CLIPTask(model, verbose=False)
+    task.train()
+    count = sum(sizes)
+    full = {
+        'image': {
+            'patches': torch.randn(count, 4, 3 * 16 * 16, dtype=torch.float64),
+            'patch_coord': torch.tensor([[0, 0], [0, 1], [1, 0], [1, 1]]).expand(count, -1, -1),
+            'patch_valid': torch.ones(count, 4, dtype=torch.bool),
+        },
+        'text': torch.randint(1, 60, (count, 8)),
+    }
+    reference_batch_size = 3
+    scale = count / (len(sizes) * reference_batch_size) if loss_scale == 'linear' else 1.0
+    losses, _ = task.training_forward(full)
+    (losses['loss'] * scale).backward()
+    expected = _grads(model)
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.0)
+    optimizer.zero_grad()
+    args = _make_args(accum_freq=len(sizes))
+    args.naflex_loss_scale = loss_scale
+    args.batch_size = reference_batch_size
+    accum_state = ([], {})
+    start = 0
+    for size in sizes:
+        batch = {
+            'image': {key: value[start:start + size] for key, value in full['image'].items()},
+            'text': full['text'][start:start + size],
+        }
+        result = _train_step_eager(
+            task, batch, accum_state, optimizer, scaler=None,
+            autocast=contextlib.nullcontext, args=args,
+        )
+        start += size
+    assert result is not None
+    actual = _grads(model)
+    assert actual.keys() == expected.keys()
+    for name in expected:
+        # NaFlex position-embedding interpolation uses FP32 internally.
+        torch.testing.assert_close(actual[name], expected[name], rtol=1e-6, atol=1e-8, msg=name)
+
+
 def _tiny_caption_task(arch, z_loss_weight):
     torch.manual_seed(0)
     vision_cfg = dict(image_size=32, layers=1, width=32, head_width=16, patch_size=16, output_tokens=True)


### PR DESCRIPTION
## Summary

Use one NaFlex linear loss scale for all replays in an accumulation window. Each replay differentiates the same cached-window loss, so scaling it by the current microbatch size gives different weights to parts of the same update.

The common scale is the average microbatch size in the window divided by the reference batch size. It preserves the existing scale for equal-size microbatches.

Fixes #1211.

## Validation

- `python -m pytest -q tests/test_grad_accum.py`: 26 passed on CPU.
- The new tests run the native NaFlex model and training step, comparing accumulated gradients with an explicitly scaled full-batch backward. They cover `[1, 2]`, `[2, 1]`, and `[2, 2]`, with linear scaling enabled and disabled.
- On unmodified `2d534609`, the two uneven linear-scaling cases fail; the other four controls pass.
- `git diff --check` and Python compilation pass.
