### PR TITLE
Respect interpolation for rectangular evaluation crops

### DIFF
--- a/src/open_clip/transform.py
+++ b/src/open_clip/transform.py
@@ -487,7 +487,7 @@ def image_transform(
                 ]
             else:
                 # resize shortest edge to matching target dim for non-square target
-                transforms = [ResizeKeepRatio(image_size)]
+                transforms = [ResizeKeepRatio(image_size, interpolation=interpolation_mode)]
             transforms += [CenterCrop(image_size)]
 
         transforms.extend([

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torchvision.transforms import InterpolationMode
+from torchvision.transforms import functional as F
+
+from open_clip.transform import image_transform
+
+
+@pytest.mark.parametrize('image_size,resized_size', [
+    ((8, 12), (8, 16)),
+    ((12, 8), (12, 24)),
+    ((8, 8), (8, 16)),
+])
+@pytest.mark.parametrize('interpolation', ['bilinear', 'bicubic'])
+def test_shortest_resize_respects_interpolation(image_size, resized_size, interpolation):
+    """Square and rectangular evaluation transforms use the requested interpolation."""
+    checkerboard = (np.indices((10, 20)).sum(axis=0) % 2 * 255).astype(np.uint8)
+    image = Image.fromarray(np.repeat(checkerboard[..., None], 3, axis=2))
+    transform = image_transform(
+        image_size,
+        is_train=False,
+        resize_mode='shortest',
+        interpolation=interpolation,
+        mean=(0., 0., 0.),
+        std=(1., 1., 1.),
+    )
+
+    resized = F.resize(image, resized_size, interpolation=InterpolationMode(interpolation))
+    expected = F.to_tensor(F.center_crop(resized, image_size))
+
+    torch.testing.assert_close(transform(image), expected)


### PR DESCRIPTION
With `image_transform(..., is_train=False, resize_mode='shortest', image_size=(8, 12), interpolation='bilinear')`, the non-square resize path constructs `ResizeKeepRatio` without the selected interpolation mode. It therefore uses bicubic interpolation, even though bilinear was requested. Square targets already use the requested mode.

Forward `interpolation_mode` to `ResizeKeepRatio` in the non-square shortest-edge path. Add pixel-level regression tests using a checkerboard image for landscape, portrait, and square target sizes with bilinear and bicubic interpolation. Expected tensors use torchvision resize with explicit dimensions, followed by center cropping.

Validation (CPU, Python 3.13.5, PyTorch 2.10.0, torchvision 0.25.0):

- Before the fix: `python -m pytest tests/test_transform.py -q` — 2 failed, 4 passed. Both failures were rectangular bilinear transforms.
- After the fix: the same command — 6 passed, including a repeat with timm 1.0.30.dev0 source on `PYTHONPATH` to satisfy the minimum timm version.
- `git diff --check` passed.

No model weights or datasets were downloaded. Full training and model suites were not run.

AI assistance: Codex helped identify the issue, implement the fix and regression tests, and review the changes. The reported local checks were executed.
