### PR TITLE
Bound SigLIP chunked training memory with activation recomputation

### DIFF
--- a/src/open_clip/loss.py
+++ b/src/open_clip/loss.py
@@ -436,7 +436,10 @@ class SigLipLoss(nn.Module):
     def _chunked_loss(self, image_features, text_features, logit_scale, logit_bias=None, negative_only=False):
         """Memory-efficient loss that chunks the logit computation.
 
-        Peak memory: O(chunk_size * N) instead of O(B * N).
+        Pairwise activation memory: O(chunk_size * N) instead of O(B * N).
+        Under autograd, each chunk is checkpointed and recomputed in backward
+        so earlier chunks' logits do not remain live until the final reduction.
+        This trades additional computation for memory; feature storage is unchanged.
         Useful when per-device batch is large (e.g. B > 4096).
 
         Uses the identities -logsigmoid(-x) = softplus(x) and
@@ -445,34 +448,42 @@ class SigLipLoss(nn.Module):
         positive needs only a -logits[k, i+k] correction.
         """
         B = image_features.shape[0]
-        N = text_features.shape[0]
         chunk_size = min(self.chunk_size, B)
         total_loss = torch.zeros((), device=image_features.device, dtype=torch.float32)
+        use_checkpoint = torch.is_grad_enabled() and any(
+            isinstance(tensor, torch.Tensor) and tensor.requires_grad
+            for tensor in (image_features, text_features, logit_scale, logit_bias)
+        )
 
         for i in range(0, B, chunk_size):
-            end_i = min(i + chunk_size, B)
-            img_chunk = image_features[i:end_i]
-            logits = self.get_logits(img_chunk, text_features, logit_scale, logit_bias)
-            # Accumulate the O(chunk_size * N) pair losses in fp32.  Without
-            # this cast, a single chunk can overflow fp16 before it is added
-            # to the fp32 running total.
-            logits = logits.float()
-
-            # Treat every pair as negative: -logsigmoid(-logits) == softplus(logits)
-            chunk_loss = F.softplus(logits).sum()
-
-            if not negative_only:
-                # Replace local positives with positive-pair loss:
-                # softplus(-x) - softplus(x) == -x, so subtract the positive logits.
-                num_pos = max(0, min(end_i, N) - i)
-                if num_pos > 0:
-                    rows = torch.arange(num_pos, device=logits.device)
-                    pos_logits = logits[rows, i + rows]
-                    chunk_loss = chunk_loss - pos_logits.sum()
-
+            img_chunk = image_features[i:i + chunk_size]
+            if use_checkpoint:
+                # Pass the offset explicitly: backward recomputation must use this
+                # chunk's positives, not the loop's final value of i.
+                chunk_loss = checkpoint(
+                    self._loss_chunk, img_chunk, text_features, logit_scale, logit_bias, i, negative_only,
+                    use_reentrant=False,
+                )
+            else:
+                chunk_loss = self._loss_chunk(
+                    img_chunk, text_features, logit_scale, logit_bias, i, negative_only)
             total_loss = total_loss + chunk_loss
 
         return total_loss / B
+
+    def _loss_chunk(self, image_features, text_features, logit_scale, logit_bias, start, negative_only):
+        logits = self.get_logits(image_features, text_features, logit_scale, logit_bias)
+        # A chunk's fp16 reduction can overflow before being added to the fp32 total.
+        logits = logits.float()
+        # Treat every pair as negative: -logsigmoid(-logits) == softplus(logits).
+        chunk_loss = F.softplus(logits).sum()
+        if not negative_only:
+            # softplus(-x) - softplus(x) == -x for each diagonal positive.
+            num_pos = max(0, min(image_features.shape[0], text_features.shape[0] - start))
+            if num_pos > 0:
+                rows = torch.arange(num_pos, device=logits.device)
+                chunk_loss = chunk_loss - logits[rows, start + rows].sum()
+        return chunk_loss
 
     def forward(self, image_features, text_features, logit_scale, logit_bias, output_dict=False):
         loss = self._loss(image_features, text_features, logit_scale, logit_bias)

--- a/tests/test_siglip_chunked_loss.py
+++ b/tests/test_siglip_chunked_loss.py
@@ -1,12 +1,14 @@
-"""Parity test for SigLipLoss with chunk_size > 0.
+"""Numerical and training-memory tests for SigLipLoss with chunk_size > 0.
 
-Verifies the chunked path matches the reference (chunk_size=0) bit-exactly
+Verifies the chunked path matches the reference (chunk_size=0)
 across multiple chunk sizes and both ground-truth modes (negative_only on/off),
 in the forward pass and the gradient.
 """
 import pytest
 import torch
+import torch.nn.functional as F
 
+import open_clip.loss as loss_module
 from open_clip.loss import SigLipLoss
 
 
@@ -55,3 +57,138 @@ def test_chunk_size_zero_skips_chunked_path():
     ref = SigLipLoss()._loss(img, txt, ls, lb)
     explicit = SigLipLoss(chunk_size=0)._loss(img, txt, ls, lb)
     assert torch.equal(ref, explicit)
+
+
+@pytest.mark.parametrize("batch_size,text_size", [(19, 19), (19, 11), (11, 19)])
+@pytest.mark.parametrize("chunk_size", [1, 7, 32])
+@pytest.mark.parametrize("negative_only", [False, True])
+@pytest.mark.parametrize("trainable", [(True, True, True, True), (False, True, True, True),
+                                     (True, False, True, True), (False, False, True, True)])
+def test_chunked_all_gradients(batch_size, text_size, chunk_size, negative_only, trainable):
+    """Chunk offsets and frozen towers preserve all feature and scalar gradients."""
+    img, txt, ls, lb = _make_inputs(B=max(batch_size, text_size))
+    inputs = (img[:batch_size], txt[:text_size], ls, lb)
+    reference_inputs = [value.clone().requires_grad_(enabled) for value, enabled in zip(inputs, trainable)]
+    chunked_inputs = [value.clone().requires_grad_(enabled) for value, enabled in zip(inputs, trainable)]
+    ref_img, ref_txt, ref_scale, ref_bias = reference_inputs
+    logits = (ref_scale * ref_img @ ref_txt.T + ref_bias).float()
+    labels = -torch.ones_like(logits)
+    if not negative_only:
+        labels.diagonal().fill_(1)
+    reference = -F.logsigmoid(labels * logits).sum() / batch_size
+    actual = SigLipLoss(chunk_size=chunk_size)._loss(*chunked_inputs, negative_only=negative_only)
+    ref_grads = torch.autograd.grad(reference, [value for value in reference_inputs if value.requires_grad])
+    actual_grads = torch.autograd.grad(actual, [value for value in chunked_inputs if value.requires_grad])
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-5)
+    for actual_grad, reference_grad in zip(actual_grads, ref_grads):
+        torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("with_bias", [False, True])
+@pytest.mark.parametrize("autocast_enabled", [False, True])
+def test_chunked_autocast_and_optional_bias(with_bias, autocast_enabled):
+    """Recomputation preserves autocast and allows an omitted logit bias."""
+    inputs = _make_inputs(B=35)
+    inputs = inputs if with_bias else inputs[:3]
+    reference_inputs = [value.clone().requires_grad_() for value in inputs]
+    chunked_inputs = [value.clone().requires_grad_() for value in inputs]
+    with torch.autocast("cpu", dtype=torch.bfloat16, enabled=autocast_enabled):
+        reference = SigLipLoss()._loss(*reference_inputs)
+        actual = SigLipLoss(chunk_size=8)._loss(*chunked_inputs)
+    ref_grads = torch.autograd.grad(reference, reference_inputs)
+    actual_grads = torch.autograd.grad(actual, chunked_inputs)
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-5)
+    for actual_grad, reference_grad in zip(actual_grads, ref_grads):
+        # Chunked bf16 matmuls accumulate feature and scalar gradients separately.
+        torch.testing.assert_close(actual_grad, reference_grad, rtol=2e-2, atol=2e-3)
+
+
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_chunked_no_grad(requires_grad):
+    """Evaluation keeps the same scalar and dictionary outputs without a graph."""
+    inputs = [value.requires_grad_(requires_grad) for value in _make_inputs(B=19)]
+    with torch.no_grad():
+        actual = SigLipLoss(chunk_size=7)(*inputs, output_dict=True)["contrastive_loss"]
+        reference = SigLipLoss()(*inputs)
+    assert not actual.requires_grad
+    torch.testing.assert_close(actual, reference)
+
+
+@pytest.mark.parametrize("trainable", [(True, True, True, True), (False, False, True, True),
+                                     (False, False, True, False), (False, False, False, True)])
+def test_chunked_saved_activation_memory(trainable):
+    """Backward must not retain every chunk's pairwise activation matrix."""
+    batch_size, feature_dim, chunk_size = 256, 16, 16
+    inputs = [value.requires_grad_(enabled)
+              for value, enabled in zip(_make_inputs(B=batch_size, D=feature_dim), trainable)]
+    input_storage = {value.untyped_storage().data_ptr() for value in inputs}
+    saved_storage = {}
+
+    def pack(tensor):
+        storage = tensor.untyped_storage()
+        if storage.data_ptr() not in input_storage:
+            saved_storage[storage.data_ptr()] = storage.nbytes()
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+        loss = SigLipLoss(chunk_size=chunk_size)._loss(*inputs)
+
+    # Count unique storage, not tensor numel: feature views share the input storage.
+    # Allow feature-sized intermediates and two chunks, but not the full B x B matrix.
+    memory_budget = 2 * (batch_size * feature_dim + chunk_size * batch_size) * inputs[0].element_size()
+    saved_bytes = sum(saved_storage.values())
+    assert saved_bytes <= memory_budget, f"saved {saved_bytes} activation bytes; budget is {memory_budget}"
+    gradients = torch.autograd.grad(loss, [value for value in inputs if value.requires_grad])
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+@pytest.mark.parametrize("dist_impl", ["gather", "reduce", "shift", "bidir"])
+@pytest.mark.parametrize("world_size", [2, 3, 4])
+def test_chunked_distributed_blocks(monkeypatch, dist_impl, world_size):
+    """Remote negative blocks keep all gradients without replaying communication.
+
+    Supply differentiable remote features directly so this test does not require
+    a distributed backend. Real collectives and their backward are not simulated.
+    """
+    image, text, scale, bias = _make_inputs(B=7, D=5)
+    texts = [text + 0.1 * rank for rank in range(world_size)]
+
+    def run(chunk_size):
+        inputs = [value.clone().requires_grad_() for value in (image, scale, bias, *texts)]
+        img, ls, lb, *all_text = inputs
+        calls = []
+        remote = iter(all_text[1:])
+
+        def gather(tensor):
+            calls.append("gather")
+            return torch.cat(all_text)
+
+        def reduce(tensor, operation):
+            index = len(calls)
+            calls.append("reduce")
+            return all_text[index]
+
+        def exchange(*args):
+            calls.append("exchange")
+            return next(remote)
+
+        def exchange_bidir(*args):
+            calls.append("exchange_bidir")
+            return next(remote), next(remote)
+
+        monkeypatch.setattr(loss_module, "_all_gather_with_grad", gather)
+        monkeypatch.setattr(torch.distributed.nn, "all_reduce", reduce)
+        monkeypatch.setattr(loss_module, "neighbour_exchange_with_grad", exchange)
+        monkeypatch.setattr(loss_module, "neighbour_exchange_bidir_with_grad", exchange_bidir)
+        loss = SigLipLoss(rank=0, world_size=world_size, dist_impl=dist_impl, chunk_size=chunk_size)(
+            img, all_text[0], ls, lb)
+        forward_calls = list(calls)
+        gradients = torch.autograd.grad(loss, inputs)
+        assert calls == forward_calls
+        return loss, gradients
+
+    reference, reference_grads = run(0)
+    actual, actual_grads = run(3)
+    torch.testing.assert_close(actual, reference, rtol=1e-5, atol=1e-5)
+    for actual_grad, reference_grad in zip(actual_grads, reference_grads):
+        torch.testing.assert_close(actual_grad, reference_grad, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
# Bound SigLIP chunked training memory with activation recomputation

With `SigLipLoss(chunk_size > 0)`, the forward loop creates small logit blocks, but autograd retains the logits from every block for `softplus` backward. The saved pairwise activations therefore still grow quadratically with batch size. This affects the memory-saving training use case introduced in #1145 and is related to #942.

This change checkpoints each complete pairwise-loss block with non-reentrant activation checkpointing. Backward recomputes the block's projection, fp32 reduction, and positive-pair correction instead of retaining all blocks' logits. Chunk offsets are explicit checkpoint inputs, and distributed collectives stay outside the recomputed function. The default unchunked path is unchanged. Frozen towers, trainable scale/bias, optional bias, and evaluation without gradients retain their behavior.

The tradeoff is additional backward computation in the already opt-in chunked path. Feature and distributed communication storage are not eliminated, and this does not claim to solve every distributed scaling issue in #942.

## Validation

- Added a regression that counts actual, deduplicated autograd-saved storage, excluding storage shared with the original inputs. Before the change, all four memory cases fail, including cases where only logit scale or bias is trainable; the other 90 correctness cases pass.
- Added loss and all-input gradient parity across chunk sizes, uneven/rectangular feature batches, negative-only blocks, frozen towers, optional bias, CPU bf16 autocast, and no-grad evaluation.
- Added differentiable remote-block tests for gather/reduce/shift/bidir and world sizes 2/3/4, checking loss/gradient parity and that backward does not replay communication. These supply remote features directly and do not replace real multi-process integration testing.
- `160 passed, 5 deselected` for the five loss test modules listed below. The five deselected cases instantiate full ViT caption models; the remaining caption-loss unit tests run.
- Small CUDA fp32/fp16/bf16 examples match the previous chunked implementation's loss and image/text/scale/bias gradients. `torch.compile(fullgraph=True, backend="eager")` forward and gradient smoke also passes.
- `git diff --check` passes.

```bash
python -m pytest tests/test_siglip_chunked_loss.py tests/test_siglip_loss_precision.py tests/test_loss.py tests/test_factory_loss.py tests/test_fused_caption_loss.py -k 'not test_fused_caption_loss_matches_legacy' -q
```

CPU saved pairwise storage before/after (fp32, embedding dimension 32):

| Batch | Chunk size | Before | After |
| --- | --- | --- | --- |
| 256 | 32 / 128 | 256 KiB | 0 additional saved pairwise storage |
| 512 | 32 / 128 | 1 MiB | 0 additional saved pairwise storage |
| 1024 | 32 / 128 | 4 MiB | 0 additional saved pairwise storage |

Checkpoint inputs still retain the original feature storage; zero in this table is not zero training memory.

Small CUDA forward + backward peak allocated-memory increments, measured above preallocated inputs after warmup with `torch.cuda.max_memory_allocated()` (batch 2048, embedding dimension 64, chunk size 64, RTX 5090, PyTorch 2.10.0+cu130):

| Projection dtype | Previous chunked implementation | This change |
| --- | --- | --- |
| fp32 | 18.016 MiB | 2.518 MiB |
| fp16 autocast | 25.524 MiB | 2.760 MiB |
| bf16 autocast | 25.524 MiB | 2.760 MiB |

These are isolated loss measurements, not whole-model training benchmarks or a throughput claim. A real three-process Gloo check could not reach the loss because this Windows build fails during process-group initialization with `makeDeviceForHostname(): unsupported gloo device`; distributed multi-process validation remains a limitation.

Developed with AI assistance; the regression failures, test results, and small CUDA measurements above were run locally.
